### PR TITLE
Fix filtering for blank PN when Android version is 16

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/FCMMessagingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/FCMMessagingService.kt
@@ -15,7 +15,7 @@ class FCMMessagingService : FirebaseMessagingService() {
   }
 
   override fun onMessageReceived(remoteMessage: RemoteMessage) {
-    if (remoteMessage.data.getOrDefault("pusherTokenValidation", "false") == "true") {
+    if (remoteMessage.data["pusherTokenValidation"] == "true") {
       log.d("Received blank message from Pusher to perform token validation")
     } else {
       log.d("Received from FCM: " + remoteMessage)


### PR DESCRIPTION
Apparently, `getOrDefault` does not exist in older versions of Android and even though I'm targetting version 16, it doesn't give any error.