### PR TITLE
Expose the FCM Message listener in the PushNotification static class

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationReceivedListener.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationReceivedListener.kt
@@ -1,11 +1,11 @@
-package com.pusher.pushnotifications.fcm
+package com.pusher.pushnotifications
 
 import com.google.firebase.messaging.RemoteMessage
 
 /**
  * The listener interface for when a remote message when the app is in the foreground.
  */
-interface FCMPushNotificationReceivedListener {
+interface PushNotificationReceivedListener {
 
   /**
    * Will be called when a new message is received.

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
@@ -2,6 +2,8 @@ package com.pusher.pushnotifications;
 
 import android.content.Context;
 
+import com.pusher.pushnotifications.fcm.FCMMessagingService;
+
 import java.util.Set;
 
 public class PushNotifications {
@@ -84,5 +86,14 @@ public class PushNotifications {
         }
 
         return instance.getSubscriptions();
+    }
+
+    /**
+     * Configures the listener that handles a remote message when the app is in the foreground.
+     *
+     * @param messageReceivedListener the listener that handles a remote message
+     */
+    public static void setOnMessageReceivedListener(PushNotificationReceivedListener messageReceivedListener) {
+        FCMMessagingService.setOnMessageReceivedListener(messageReceivedListener);
     }
 }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/FCMMessagingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/FCMMessagingService.kt
@@ -2,11 +2,12 @@ package com.pusher.pushnotifications.fcm
 
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.pusher.pushnotifications.PushNotificationReceivedListener
 import com.pusher.pushnotifications.logging.Logger
 
 class FCMMessagingService : FirebaseMessagingService() {
   companion object {
-    private var listener: FCMPushNotificationReceivedListener? = null
+    private var listener: PushNotificationReceivedListener? = null
     private val log = Logger.get(this::class)
 
     /**
@@ -15,7 +16,7 @@ class FCMMessagingService : FirebaseMessagingService() {
      * @param messageReceivedListener the listener that handles a remote message
      */
     @JvmStatic
-    fun setOnMessageReceivedListener(messageReceivedListener: FCMPushNotificationReceivedListener) {
+    fun setOnMessageReceivedListener(messageReceivedListener: PushNotificationReceivedListener) {
       listener = messageReceivedListener
     }
   }


### PR DESCRIPTION
So we can recommend:

```
        PushNotifications.setOnMessageReceivedListener();
```

Instead of:
```
        FCMMessagingService.setOnMessageReceivedListener();
```