### PR TITLE
Tell proguard not to interfere with our classes

### DIFF
--- a/pushnotifications/proguard-rules.pro
+++ b/pushnotifications/proguard-rules.pro
@@ -27,3 +27,8 @@
 -keep class android.support.v4.app.NotificationCompat$* { *; }
 
 -keep class android.support.v4.app.NotificationManagerCompat { *; }
+
+## Overzealous rule, but future proof
+-keep class com.pusher.pushnotifications.** {
+  *;
+}


### PR DESCRIPTION
We are using Retrofit, that uses reflection, so we don't want proguard to changes our API models.