### PR TITLE
Only sync on boot if necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+ - Improve interest set synchronization when booting
+
 ## [0.10.1] - 2018-06-25
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/DeviceStateStore.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/DeviceStateStore.kt
@@ -9,6 +9,7 @@ class DeviceStateStore(context: Context) {
   private val preferencesOSVersionKey = "osVersion"
   private val preferencesSDKVersionKey = "sdkVersion"
   private val preferencesInterestsKey = "interests"
+  private val serverConfirmedInterestsHashKey = "serverConfirmedInterestsHash"
 
   private val preferences = context.getSharedPreferences(
     "com.pusher.pushnotifications.PushNotificationsInstance", Context.MODE_PRIVATE)
@@ -38,4 +39,8 @@ class DeviceStateStore(context: Context) {
     // by the Android SDK
     get() = preferences.getStringSet(preferencesInterestsKey, mutableSetOf<String>()).toMutableSet()
     set(value) = preferences.edit().putStringSet(preferencesInterestsKey, value).apply()
+
+  var serverConfirmedInterestsHash: String?
+    get() = preferences.getString(serverConfirmedInterestsHashKey, null)
+    set(value) = preferences.edit().putString(serverConfirmedInterestsHashKey, value).apply()
 }


### PR DESCRIPTION
We don't need to always send the interest set when booting.