### PR TITLE
Fix incorrect boolean logic in replaceAllInterestsInStore.

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -79,7 +79,7 @@ class PushNotificationsInstance(
 
   private fun replaceAllInterestsInStore(interests: Set<String>): Boolean {
     val localInterests = deviceStateStore.interests
-    val areInterestsDifferent = localInterests.containsAll(interests) && interests.containsAll(localInterests)
+    val areInterestsDifferent = !(localInterests.containsAll(interests) && interests.containsAll(localInterests))
     if (areInterestsDifferent) {
       deviceStateStore.interests = localInterests
       return true

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -81,7 +81,7 @@ class PushNotificationsInstance(
     val localInterests = deviceStateStore.interests
     val areInterestsDifferent = !(localInterests.containsAll(interests) && interests.containsAll(localInterests))
     if (areInterestsDifferent) {
-      deviceStateStore.interests = localInterests
+      deviceStateStore.interests = interests.toMutableSet()
       return true
     }
     return false // nothing changed


### PR DESCRIPTION
`a.containsAll(b) && b.containsAll(a)` is true only when a and b are equals (i.e. contains the same elements).
An additional ! is needed if willing to find out whether a and b are different.

This should fix https://github.com/pusher/push-notifications-android/issues/56 and similar issues.