### PR TITLE
Support multiple instantiations of PushNotificationsInstance

### DIFF
--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/FakeErrol.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/FakeErrol.kt
@@ -102,6 +102,16 @@ class FakeErrol(port: Int): NanoHTTPDRouter(port) {
       }
     }
 
+    delete("/instances/{instanceId}/devices/fcm/{deviceId}/interests/{interest}") {
+      val device = storage.devices[params["deviceId"]]
+      if (device != null) {
+        device.interests.remove(params["interest"]!!)
+        complete(Response.Status.OK)
+      } else {
+        complete(Response.Status.NOT_FOUND)
+      }
+    }
+
     put("/instances/{instanceId}/devices/fcm/{deviceId}/interests") {
       entity(SetSubscriptionsRequest::class) { setSubscriptions ->
         val device = storage.devices[params["deviceId"]]

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -40,14 +40,11 @@ class PushNotificationsInstance(
   private var onSubscriptionsChangedListener: SubscriptionsChangedListener? = null
 
   private val serverSyncHandler = {
-    val handlerThread = HandlerThread("ServerSyncHandler-$instanceId")
-    handlerThread.start()
-
-    ServerSyncHandler(
+    ServerSyncHandler.obtain(
+        instanceId = instanceId,
         api = PushNotificationsAPI(instanceId, sdkConfig.overrideHostURL),
         deviceStateStore = deviceStateStore,
-        jobQueue = TapeJobQueue(File(context.filesDir, "$instanceId.jobqueue")),
-        looper = handlerThread.looper
+        jobQueue = TapeJobQueue(File(context.filesDir, "$instanceId.jobqueue"))
     )
   }()
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -44,7 +44,7 @@ class PushNotificationsInstance(
         instanceId = instanceId,
         api = PushNotificationsAPI(instanceId, sdkConfig.overrideHostURL),
         deviceStateStore = deviceStateStore,
-        jobQueue = TapeJobQueue(File(context.filesDir, "$instanceId.jobqueue"))
+        secureFileDir = context.filesDir
     )
   }()
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -3,9 +3,6 @@ package com.pusher.pushnotifications
 import java.util.regex.Pattern
 import android.content.Context
 import android.os.Build
-import android.os.Handler
-import android.os.HandlerThread
-import android.os.Looper
 import com.google.firebase.iid.FirebaseInstanceId
 import com.pusher.pushnotifications.api.DeviceMetadata
 import com.pusher.pushnotifications.api.PushNotificationsAPI
@@ -13,7 +10,6 @@ import com.pusher.pushnotifications.fcm.MessagingService
 import com.pusher.pushnotifications.internal.*
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.validation.Validations
-import java.io.File
 
 /**
  * Thrown when the device is re-registered to a different instance id. If you wish to register a

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
@@ -42,7 +42,7 @@ sealed class RetryStrategy<T> {
         } catch (e: PushNotificationsAPIBadRequest) {
           // not recoverable
           throw e
-        } catch (e: RuntimeException) {
+        } catch (e: Exception) {
         }
 
         retryCount++

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
@@ -19,7 +19,7 @@ data class UnsubscribeJob(val interest: String): ServerSyncJob()
 data class SetSubscriptionsJob(val interests: Set<String>): ServerSyncJob()
 data class ApplicationStartJob(val deviceMetadata: DeviceMetadata): ServerSyncJob()
 
-class ServerSyncHandler(
+class ServerSyncHandler private constructor(
     private val api: PushNotificationsAPI,
     private val deviceStateStore: DeviceStateStore,
     private val jobQueue: PersistentJobQueue<ServerSyncJob>,
@@ -53,27 +53,45 @@ class ServerSyncHandler(
   }
 
   companion object {
-  fun refreshToken(fcmToken: String): Message =
-      Message.obtain().apply { obj = RefreshTokenJob(fcmToken) }
+    private val serverSyncHandlers = mutableMapOf<String, ServerSyncHandler>()
 
-  fun start(fcmToken: String, knownPreviousClientIds: List<String>): Message =
-      Message.obtain().apply { obj = StartJob(fcmToken, knownPreviousClientIds) }
+    fun obtain(
+        instanceId: String,
+        api: PushNotificationsAPI,
+        deviceStateStore: DeviceStateStore,
+        jobQueue: PersistentJobQueue<ServerSyncJob>
+    ): ServerSyncHandler {
+      return synchronized(serverSyncHandlers) {
+        serverSyncHandlers.getOrPut(instanceId) {
+          val handlerThread = HandlerThread("ServerSyncHandler-$instanceId")
+          handlerThread.start()
 
-  fun subscribe(interest: String): Message =
-      Message.obtain().apply { obj = SubscribeJob(interest) }
+          ServerSyncHandler(api, deviceStateStore, jobQueue, handlerThread.looper)
+        }
+      }
+    }
 
-  fun unsubscribe(interest: String): Message =
-      Message.obtain().apply { obj = UnsubscribeJob(interest) }
+    fun refreshToken(fcmToken: String): Message =
+        Message.obtain().apply { obj = RefreshTokenJob(fcmToken) }
 
-  fun setSubscriptions(interests: Set<String>): Message =
-      Message.obtain().apply { obj = SetSubscriptionsJob(interests) }
+    fun start(fcmToken: String, knownPreviousClientIds: List<String>): Message =
+        Message.obtain().apply { obj = StartJob(fcmToken, knownPreviousClientIds) }
 
-  fun applicationStart(deviceMetadata: DeviceMetadata): Message =
-      Message.obtain().apply { obj = ApplicationStartJob(deviceMetadata) }
+    fun subscribe(interest: String): Message =
+        Message.obtain().apply { obj = SubscribeJob(interest) }
+
+    fun unsubscribe(interest: String): Message =
+        Message.obtain().apply { obj = UnsubscribeJob(interest) }
+
+    fun setSubscriptions(interests: Set<String>): Message =
+        Message.obtain().apply { obj = SetSubscriptionsJob(interests) }
+
+    fun applicationStart(deviceMetadata: DeviceMetadata): Message =
+        Message.obtain().apply { obj = ApplicationStartJob(deviceMetadata) }
   }
 }
 
-class ServerSyncProcessHandler(
+class ServerSyncProcessHandler internal constructor(
     private val api: PushNotificationsAPI,
     private val deviceStateStore: DeviceStateStore,
     private val jobQueue: PersistentJobQueue<ServerSyncJob>,
@@ -118,12 +136,9 @@ class ServerSyncProcessHandler(
             retryStrategy = RetryStrategy.WithInfiniteExpBackOff())
 
     synchronized(deviceStateStore) {
-      deviceStateStore.deviceId = registrationResponse.deviceId
-      deviceStateStore.FCMToken = startJob.fcmToken
-
       // Replay sub/unsub/setsub operations in job queue over initial interest set
       val interests = registrationResponse.initialInterests.toMutableSet()
-      for(j in jobQueue.asIterable()) {
+      for (j in jobQueue.asIterable()) {
         if (j is StartJob) {
           break
         }
@@ -155,6 +170,15 @@ class ServerSyncProcessHandler(
       }
     }
 
+    deviceStateStore.deviceId = registrationResponse.deviceId
+    deviceStateStore.FCMToken = startJob.fcmToken
+
+    // Clear queue up to the start job
+    while (jobQueue.peek() !is StartJob) {
+      jobQueue.pop()
+    }
+    jobQueue.pop() // Also remove start job
+
     val remoteInterestsWillChange = deviceStateStore.interests != registrationResponse.initialInterests
     if (remoteInterestsWillChange) {
       api.setSubscriptions(
@@ -162,12 +186,6 @@ class ServerSyncProcessHandler(
           interests = deviceStateStore.interests,
           retryStrategy = RetryStrategy.WithInfiniteExpBackOff())
     }
-
-    // Clear queue up to the start job
-    while (jobQueue.peek() !is StartJob) {
-      jobQueue.pop()
-    }
-    jobQueue.pop() // Also remove start job
   }
 
   private fun processApplicationStartJob(job: ApplicationStartJob) {
@@ -259,7 +277,7 @@ class ServerSyncProcessHandler(
       return
     }
 
-    if(job is StartJob) {
+    if (job is StartJob) {
       processStartJob(job)
     } else {
       processJob(job)

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
@@ -7,6 +7,7 @@ import android.os.Message
 import com.pusher.pushnotifications.SubscriptionsChangedListener
 import com.pusher.pushnotifications.api.*
 import com.pusher.pushnotifications.logging.Logger
+import java.io.File
 import java.io.Serializable
 import java.math.BigInteger
 import java.security.MessageDigest
@@ -59,13 +60,14 @@ class ServerSyncHandler private constructor(
         instanceId: String,
         api: PushNotificationsAPI,
         deviceStateStore: DeviceStateStore,
-        jobQueue: PersistentJobQueue<ServerSyncJob>
+        secureFileDir: File
     ): ServerSyncHandler {
       return synchronized(serverSyncHandlers) {
         serverSyncHandlers.getOrPut(instanceId) {
           val handlerThread = HandlerThread("ServerSyncHandler-$instanceId")
           handlerThread.start()
 
+          val jobQueue = TapeJobQueue<ServerSyncJob>(File(secureFileDir, "$instanceId.jobqueue"))
           ServerSyncHandler(api, deviceStateStore, jobQueue, handlerThread.looper)
         }
       }


### PR DESCRIPTION
The previous refactor didn't quite handle the case where multiple instances of PushNotificationsInstances were being created.