### PR TITLE
Add an SDK stop function

### DIFF
--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
@@ -10,6 +10,7 @@ import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.junit.After
+import org.junit.AfterClass
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,6 +38,12 @@ class DeviceRegistrationTest {
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
   companion object {
     val errol = FakeErrol(8080)
+
+    @AfterClass
+    @JvmStatic
+    fun shutdownFakeErrol() {
+      errol.stop()
+    }
   }
 
   @Before

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
@@ -1,0 +1,121 @@
+package com.example.pushnotificationsintegrationtests
+
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.pusher.pushnotifications.PushNotificationsInstance
+import com.pusher.pushnotifications.internal.DeviceStateStore
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.After
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+import org.junit.Before
+import java.io.File
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class StopTest {
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    return deviceStateStore.deviceId
+  }
+
+  val context = InstrumentationRegistry.getTargetContext()
+  val instanceId = "00000000-1241-08e9-b379-377c32cd1e89"
+  val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
+  companion object {
+    val errol = FakeErrol(8080)
+  }
+
+  @Before
+  @After
+  fun cleanup() {
+    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    assertTrue(deviceStateStore.clear())
+    assertNull(deviceStateStore.deviceId)
+    assertThat(deviceStateStore.interests.size, `is`(equalTo(0)))
+
+    File(context.filesDir, "$instanceId.jobqueue").delete()
+  }
+
+  @Test
+  fun stopShouldDeleteADeviceInTheServer() {
+    // Start the SDK
+    val pni = PushNotificationsInstance(context, instanceId)
+    pni.start()
+    Thread.sleep(DEVICE_REGISTRATION_WAIT_MS)
+
+    // A device ID should have been stored
+    val storedDeviceId = getStoredDeviceId()
+    assertNotNull(storedDeviceId)
+
+    // and the stored id should match the server one
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+
+    pni.stop()
+
+    Thread.sleep(1000)
+
+    // and now the server should not have this device anymore
+    assertNull(errolClient.getDevice(storedDeviceId!!))
+  }
+
+  @Test
+  fun stopShouldDeleteLocalInterests() {
+    // Start the SDK
+    val pni = PushNotificationsInstance(context, instanceId)
+    pni.subscribe("potato")
+    pni.start()
+    Thread.sleep(DEVICE_REGISTRATION_WAIT_MS)
+
+    // A device ID should have been stored
+    val storedDeviceId = getStoredDeviceId()
+    assertNotNull(storedDeviceId)
+
+    // and the stored id should match the server one
+    val getDeviceResponse = errolClient.getDevice(storedDeviceId!!)
+    assertNotNull(getDeviceResponse)
+
+    pni.stop()
+    assertThat(pni.getSubscriptions(), `is`(emptySet()))
+  }
+
+  @Test
+  fun afterStoppingStartShouldBePossible() {
+    // Start the SDK
+    val pni = PushNotificationsInstance(context, instanceId)
+    pni.start()
+    Thread.sleep(DEVICE_REGISTRATION_WAIT_MS)
+
+    // A device ID should have been stored
+    val storedDeviceId = getStoredDeviceId()
+    assertNotNull(storedDeviceId)
+
+    // and the stored id should match the server one
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+
+    pni.stop()
+
+    Thread.sleep(1000)
+
+    // and now the server should not have this device anymore
+    assertNull(errolClient.getDevice(storedDeviceId!!))
+
+    pni.start()
+    Thread.sleep(DEVICE_REGISTRATION_WAIT_MS)
+
+    // A device ID should have been stored
+    val newStoredDeviceId = getStoredDeviceId()
+    assertNotNull(newStoredDeviceId)
+    assertNotNull(errolClient.getDevice(newStoredDeviceId!!))
+  }
+}

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
@@ -8,6 +8,7 @@ import com.pusher.pushnotifications.internal.DeviceStateStore
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.CoreMatchers.equalTo
 import org.junit.After
+import org.junit.AfterClass
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +35,12 @@ class StopTest {
 
   companion object {
     val errol = FakeErrol(8080)
+
+    @AfterClass
+    @JvmStatic
+    fun shutdownFakeErrol() {
+      DeviceRegistrationTest.errol.stop()
+    }
   }
 
   @Before

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
@@ -5,8 +5,7 @@ import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.internal.DeviceStateStore
-import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.*
 import org.junit.After
 import org.junit.AfterClass
 
@@ -124,5 +123,6 @@ class StopTest {
     val newStoredDeviceId = getStoredDeviceId()
     assertNotNull(newStoredDeviceId)
     assertNotNull(errolClient.getDevice(newStoredDeviceId!!))
+    assertThat(newStoredDeviceId, `is`(not(equalTo(storedDeviceId))))
   }
 }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -220,4 +220,18 @@ class PushNotificationsInstance(
 
     serverSyncHandler.sendMessage(ServerSyncHandler.applicationStart(deviceMetadata))
   }
+
+  fun stop() {
+    synchronized(deviceStateStore) {
+      val hadAnyInterests = deviceStateStore.interests.isNotEmpty()
+
+      deviceStateStore.interests = mutableSetOf()
+      deviceStateStore.startHasBeenCalled = false
+      serverSyncHandler.sendMessage(ServerSyncHandler.stop())
+
+      if (hadAnyInterests) {
+        onSubscriptionsChangedListener?.onSubscriptionsChanged(emptySet())
+      }
+    }
+  }
 }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationService.kt
@@ -45,6 +45,12 @@ interface PushNotificationService {
     @Path("deviceId") deviceId: String,
     @Body metadata: DeviceMetadata
   ): Call<Void>
+
+  @DELETE("instances/{instanceId}/devices/fcm/{deviceId}")
+  fun delete(
+    @Path("instanceId") instanceId: String,
+    @Path("deviceId") deviceId: String
+  ): Call<Void>
 }
 
 data class NOKResponse(


### PR DESCRIPTION
Adds a mechanism to completely wipe the device from local storage and to delete the device records from the server.