### PR TITLE
Better app in background reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+ - Sometimes notifications were being marked as delivered with the app being in background.
+
 ## [1.2.0] - 2019-02-06
 
 ### Added

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
 
-    implementation 'android.arch.lifecycle:extensions:1.1.1'
+    implementation 'android.arch.lifecycle:extensions:1.1.0'
 
     lintChecks project(':pushnotifications-lint')
 }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
 
+    implementation 'android.arch.lifecycle:extensions:1.1.1'
+
     lintChecks project(':pushnotifications-lint')
 }
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -9,8 +9,6 @@ import com.google.gson.JsonSyntaxException
 import com.pusher.pushnotifications.internal.DeviceStateStore
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.OpenEvent
-import com.pusher.pushnotifications.reporting.api.ReportEvent
-import com.pusher.pushnotifications.reporting.api.ReportEventType
 
 /*
  * This activity will be opened when a user taps a notification sent by the Pusher push notifications

--- a/sample_kotlin/src/main/res/layout/activity_main.xml
+++ b/sample_kotlin/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.pusher.sample.com.pusher.pushnotifications.MainActivity">
+    tools:context="com.pusher.pushnotifications.sample.MainActivity">
 
     <TextView
         android:layout_width="wrap_content"


### PR DESCRIPTION
We noticed that the `app in background` field was being marked too often as "true". After some investigation, I've decided to use a known library to check for the process lifecycle state and rely on that instead of our "less-than-optimal" counters.