### PR TITLE
Send userId field if available when reporting notification events

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -33,7 +33,9 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
           return
         }
 
-        val deviceId = DeviceStateStore(context).deviceId
+        val deviceStateStore = DeviceStateStore(context)
+
+        val deviceId = deviceStateStore.deviceId
         if (deviceId == null) {
           log.w("Failed to get device ID (device ID not stored) - Skipping delivery tracking.")
           return
@@ -42,7 +44,7 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
         val reportEvent = DeliveryEvent(
           publishId = pusherData.publishId,
           deviceId = deviceId,
-          userId = pusherData.userId,
+          userId = deviceStateStore.userId,
           timestampSecs = Math.round(System.currentTimeMillis() / 1000.0),
           appInBackground = AppActivityLifecycleCallbacks.appInBackground(),
           hasDisplayableContent = pusherData.hasDisplayableContent,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -12,8 +12,6 @@ import com.pusher.pushnotifications.internal.AppActivityLifecycleCallbacks
 import com.pusher.pushnotifications.internal.DeviceStateStore
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.DeliveryEvent
-import com.pusher.pushnotifications.reporting.api.ReportEvent
-import com.pusher.pushnotifications.reporting.api.ReportEventType
 
 class FCMMessageReceiver : WakefulBroadcastReceiver() {
   private val gson = Gson()
@@ -43,7 +41,8 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
 
         val reportEvent = DeliveryEvent(
           publishId = pusherData.publishId,
-          deviceId =   deviceId,
+          deviceId = deviceId,
+          userId = pusherData.userId,
           timestampSecs = Math.round(System.currentTimeMillis() / 1000.0),
           appInBackground = AppActivityLifecycleCallbacks.appInBackground(),
           hasDisplayableContent = pusherData.hasDisplayableContent,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -48,11 +48,12 @@ class OpenNotificationActivity: Activity() {
 
         intent?.getStringExtra("pusher")?.let { pusherDataJson ->
             try {
+                val deviceStateStore = DeviceStateStore(applicationContext)
                 val gson = Gson()
                 val pusherData = gson.fromJson(pusherDataJson, PusherMetadata::class.java)
                 log.i("Got a valid pusher message.")
 
-                val deviceId = DeviceStateStore(applicationContext).deviceId
+                val deviceId = deviceStateStore.deviceId
                 if (deviceId == null) {
                     log.e("Failed to get device ID (device ID not stored) - Skipping open tracking.")
                     startIntent(intent.extras)
@@ -62,7 +63,7 @@ class OpenNotificationActivity: Activity() {
                 val reportEvent = OpenEvent(
                    publishId = pusherData.publishId,
                    deviceId = deviceId,
-                   userId = pusherData.userId,
+                   userId = deviceStateStore.userId,
                    timestampSecs = System.currentTimeMillis() / 1000
                 )
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -62,6 +62,7 @@ class OpenNotificationActivity: Activity() {
                 val reportEvent = OpenEvent(
                    publishId = pusherData.publishId,
                    deviceId = deviceId,
+                   userId = pusherData.userId,
                    timestampSecs = System.currentTimeMillis() / 1000
                 )
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -6,12 +6,12 @@ import com.firebase.jobdispatcher.JobService
 import com.google.gson.annotations.SerializedName
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.PushNotificationsInstance
-import com.pusher.pushnotifications.api.OperationCallback
 import com.pusher.pushnotifications.api.OperationCallbackNoArgs
 import com.pusher.pushnotifications.reporting.api.*
 
 data class PusherMetadata(
   val publishId: String,
+  val userId: String?,
   val clickAction: String?,
   @SerializedName("hasDisplayableContent") private val _hasDisplayableContent: Boolean?,
   @SerializedName("hasData") private val _hasData: Boolean?
@@ -21,13 +21,13 @@ data class PusherMetadata(
 
   val hasData: Boolean
     get() = _hasData ?: false
-
 }
 
 class ReportingJobService: JobService() {
   companion object {
     private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
     private const val BUNDLE_DEVICE_ID_KEY = "DeviceId"
+    private const val BUNDLE_USER_ID_KEY = "UserId"
     private const val BUNDLE_PUBLISH_ID_KEY = "PublishId"
     private const val BUNDLE_TIMESTAMP_KEY = "Timestamp"
     private const val BUNDLE_APP_IN_BACKGROUND_KEY = "AppInBackground"
@@ -40,6 +40,7 @@ class ReportingJobService: JobService() {
         is DeliveryEvent -> {
           b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
           b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
           b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
           b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
           b.putBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, reportEvent.appInBackground!!)
@@ -50,6 +51,7 @@ class ReportingJobService: JobService() {
         is OpenEvent -> {
           b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
           b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
           b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
           b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
         }
@@ -64,6 +66,7 @@ class ReportingJobService: JobService() {
         ReportEventType.Delivery -> {
           return DeliveryEvent(
             deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
+            userId = bundle.getString(BUNDLE_USER_ID_KEY),
             publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
             timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
             appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
@@ -74,6 +77,7 @@ class ReportingJobService: JobService() {
         ReportEventType.Open -> {
           return OpenEvent(
             deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
+            userId = bundle.getString(BUNDLE_USER_ID_KEY),
             publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
             timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
           )

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -11,7 +11,6 @@ import com.pusher.pushnotifications.reporting.api.*
 
 data class PusherMetadata(
   val publishId: String,
-  val userId: String?,
   val clickAction: String?,
   @SerializedName("hasDisplayableContent") private val _hasDisplayableContent: Boolean?,
   @SerializedName("hasData") private val _hasData: Boolean?

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingService.kt
@@ -18,6 +18,7 @@ enum class ReportEventType {
 sealed class ReportEvent(
   val event: ReportEventType,
   val deviceId: String,
+  val userId: String?,
   val publishId: String,
   val timestampSecs: Long,
   val appInBackground: Boolean? = null,
@@ -27,16 +28,17 @@ sealed class ReportEvent(
 
 class OpenEvent (
   deviceId: String,
+  userId: String?,
   publishId: String,
   timestampSecs: Long
-): ReportEvent(ReportEventType.Open, deviceId, publishId, timestampSecs)
+): ReportEvent(ReportEventType.Open, deviceId, userId, publishId, timestampSecs)
 
 class DeliveryEvent (
   deviceId: String,
+  userId: String?,
   publishId: String,
   timestampSecs: Long,
   appInBackground: Boolean,
   hasDisplayableContent: Boolean,
   hasData: Boolean
-): ReportEvent(ReportEventType.Delivery, deviceId, publishId, timestampSecs, appInBackground, hasDisplayableContent, hasData)
-
+): ReportEvent(ReportEventType.Delivery, deviceId, userId, publishId, timestampSecs, appInBackground, hasDisplayableContent, hasData)


### PR DESCRIPTION
We want to send `userId` to make it easy to support the webhooks we are planning to release.