### PR TITLE
Set link data on new intent for notification clicks

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -2,6 +2,7 @@ package com.pusher.pushnotifications.reporting
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.firebase.jobdispatcher.*
 import com.google.gson.Gson
@@ -29,6 +30,15 @@ class OpenNotificationActivity: Activity() {
         }
 
         i.replaceExtras(bundle)
+
+        val link: String
+
+        link = i.getStringExtra("link")
+
+        if(link != null) {
+          log.i("Set link as data $link")
+          i.setData(Uri.parse(link))
+        }
 
         // We need to clear the activity stack so that this activity doesn't show up when customers
         // are debugging.


### PR DESCRIPTION
When specifying the `fcm` you can now include `link` and that url will be specified as data on the new intent.

```
fcm: {
  notification: {
    title: "New friend!",
    body: "Have a look at your new friend"
    click_action: "android.intent.action.VIEW",
  },
  data: {
    link: "myapp://friends"
  }
}`
```

Add a new intent to your manifest that handles deep linking.

```
<intent-filter>
  <action android:name="android.intent.action.VIEW" />
  <category android:name="android.intent.category.DEFAULT" />
  <category android:name="android.intent.category.BROWSABLE" />
  <data android:scheme="myapp" />
</intent-filter>
```

That way it is possible to do deep linking and using intents in Android. 

This is a case for the React Native library where we want deep linking and an initial url to be set when opening the app by clicking a notification.