### PR TITLE
Fix issue with Tape with Invalid Class Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix issue #77 Invalid Class Exceptions in Tape
 
 ## [1.4.1] - 2019-05-24
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
@@ -39,8 +39,8 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
      try {
       @Suppress("unchecked_cast")
       return objectInputStream.readObject() as T
-    } catch (e: InvalidClassException){
-       log.w("Failed to read data from tape")
+    } catch (e: InvalidClassException) {
+       log.w("Failed to read data from tape. Continuing without this data.")
     }
 
     return null
@@ -68,7 +68,7 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
           @Suppress("unchecked_cast")
           objectInputStream.readObject() as T
         } catch (e: InvalidClassException) {
-          log.w("Failed to read data from tape")
+          log.w("Failed to read data from tape. Continuing without this data.")
           null
         }
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
@@ -1,5 +1,6 @@
 package com.pusher.pushnotifications.internal
 
+import com.pusher.pushnotifications.logging.Logger
 import com.squareup.tape2.QueueFile
 import java.io.*
 
@@ -13,6 +14,7 @@ interface PersistentJobQueue<T: Serializable> {
 
 class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
   private val queueFile = QueueFile.Builder(file).build()
+  private val log = Logger.get(this::class)
 
   override fun push(job: T) {
     val byteOutputStream = ByteArrayOutputStream()
@@ -26,7 +28,6 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
     }
   }
 
-  @Suppress("unchecked_cast")
   override fun peek(): T? {
     val jobBytes = synchronized(queueFile) {
       queueFile.peek() ?: return null
@@ -35,7 +36,14 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
     val byteInputStream = ByteArrayInputStream(jobBytes)
     val objectInputStream = ObjectInputStream(byteInputStream)
 
-    return objectInputStream.readObject() as T
+     try {
+      @Suppress("unchecked_cast")
+      return objectInputStream.readObject() as T
+    } catch (e: InvalidClassException){
+       log.w("Failed to read data from tape ")
+    }
+
+    return null
   }
 
   override fun pop() {
@@ -49,16 +57,22 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
       queueFile.clear()
     }
   }
-
-  @Suppress("unchecked_cast")
+  
   override fun asIterable(): Iterable<T> {
     return synchronized(queueFile) {
       queueFile.asIterable().map { jobBytes ->
         val byteInputStream = ByteArrayInputStream(jobBytes)
         val objectInputStream = ObjectInputStream(byteInputStream)
 
-        objectInputStream.readObject() as T
-      }.toList() // forcing the list to be computed here in its entirety
+        try {
+          @Suppress("unchecked_cast")
+          objectInputStream.readObject() as T
+        } catch (e: InvalidClassException) {
+          log.w("Failed to read data from tape ")
+          null
+        }
+
+      }.filterNotNull().toList() // forcing the list to be computed here in its entirety
     }
   }
 }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
@@ -40,7 +40,7 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
       @Suppress("unchecked_cast")
       return objectInputStream.readObject() as T
     } catch (e: InvalidClassException){
-       log.w("Failed to read data from tape ")
+       log.w("Failed to read data from tape")
     }
 
     return null
@@ -57,7 +57,7 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
       queueFile.clear()
     }
   }
-  
+
   override fun asIterable(): Iterable<T> {
     return synchronized(queueFile) {
       queueFile.asIterable().map { jobBytes ->
@@ -68,7 +68,7 @@ class TapeJobQueue<T: Serializable>(file: File): PersistentJobQueue<T> {
           @Suppress("unchecked_cast")
           objectInputStream.readObject() as T
         } catch (e: InvalidClassException) {
-          log.w("Failed to read data from tape ")
+          log.w("Failed to read data from tape")
           null
         }
 


### PR DESCRIPTION
This happened when you wrote one kind of data to the tape file, and tried to read another.

I've moved the suppress warning to be directly above where the warning occurred to make it easier for people to know what's being suppressed.

Also added some warning logs with the following message `Failed to read data from tape` - happy to take suggestions on better wording for this?

Also working on trying to write a test to reproduce this fix.