### PR TITLE
Further protect against parsing exceptions as they are best effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix issue #85 JsonEncodingException when loading stored pending operations
+
 ## [1.4.3] - 2019-06-07
 
 ### Changed

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/PersistentJobQueue.kt
@@ -2,6 +2,7 @@ package com.pusher.pushnotifications.internal
 
 import com.pusher.pushnotifications.logging.Logger
 import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonEncodingException
 import com.squareup.tape2.ObjectQueue
 import com.squareup.tape2.QueueFile
 import java.io.*
@@ -20,6 +21,9 @@ class TapeJobQueue<T: Serializable>(file: File, converter: ObjectQueue.Converter
     override fun from(source: ByteArray): T? {
       return try {
         converter.from(source)
+      } catch (ex: JsonEncodingException) {
+        log.w("Failed to read object data from tape. Continuing without this data.")
+        null
       } catch (ex: JsonDataException) {
         log.w("Failed to read object data from tape. Continuing without this data.")
         null


### PR DESCRIPTION
Fixes #84.

I think our internal testing only showed `JsonDataException`, but looking at the library, it's feasible that it might also throw `JsonEncodingException`.

We should handle both the same way.