### PR TITLE
Preserve the server reason for a 400

### DIFF
--- a/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
+++ b/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
@@ -4,6 +4,7 @@ import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.pusher.pushnotifications.api.DeviceMetadata
 import com.pusher.pushnotifications.api.PushNotificationsAPI
+import com.pusher.pushnotifications.api.PushNotificationsAPIBadRequest
 import com.pusher.pushnotifications.api.PushNotificationsAPIUnprocessableEntity
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.internal.*

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
@@ -20,7 +20,7 @@ class PushNotificationsAPIUnprocessableEntity(val reason: String): PushNotificat
     "The request was deemed to be unprocessable: $reason"
 )
 class PushNotificationsAPIDeviceNotFound: PushNotificationsAPIException("Device not found in the server")
-class PushNotificationsAPIBadRequest: PushNotificationsAPIException("A request to the server has been deemed invalid")
+class PushNotificationsAPIBadRequest(val reason: String): PushNotificationsAPIException("A request to the server has been deemed invalid: $reason")
 class PushNotificationsAPIBadJWT(val reason: String): PushNotificationsAPIException(
     "The request was rejected because the JWT was invalid/unauthorized: $reason"
 )
@@ -168,7 +168,8 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
         throw PushNotificationsAPIDeviceNotFound()
       }
       if (response.code() == 400) {
-        throw PushNotificationsAPIBadRequest()
+        val reason = response?.errorBody()?.let { safeExtractJsonError(it.string()).description }
+        throw PushNotificationsAPIBadRequest(reason ?: "Unknown reason")
       }
 
       if (response.code() !in 200..299) {
@@ -195,7 +196,8 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
         throw PushNotificationsAPIDeviceNotFound()
       }
       if (response.code() == 400) {
-        throw PushNotificationsAPIBadRequest()
+        val reason = response?.errorBody()?.let { safeExtractJsonError(it.string()).description }
+        throw PushNotificationsAPIBadRequest(reason ?: "Unknown reason")
       }
 
       if (response.code() !in 200..299) {
@@ -222,7 +224,8 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
         throw PushNotificationsAPIDeviceNotFound()
       }
       if (response.code() == 400) {
-        throw PushNotificationsAPIBadRequest()
+        val reason = response?.errorBody()?.let { safeExtractJsonError(it.string()).description }
+        throw PushNotificationsAPIBadRequest(reason ?: "Unknown reason")
       }
 
       if (response.code() !in 200..299) {
@@ -249,7 +252,8 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
         throw PushNotificationsAPIDeviceNotFound()
       }
       if (response.code() == 400) {
-        throw PushNotificationsAPIBadRequest()
+        val reason = response?.errorBody()?.let { safeExtractJsonError(it.string()).description }
+        throw PushNotificationsAPIBadRequest(reason ?: "Unknown reason")
       }
 
       if (response.code() !in 200..299) {
@@ -280,7 +284,8 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
         throw PushNotificationsAPIDeviceNotFound()
       }
       if (response.code() == 400) {
-        throw PushNotificationsAPIBadRequest()
+        val reason = response?.errorBody()?.let { safeExtractJsonError(it.string()).description }
+        throw PushNotificationsAPIBadRequest(reason ?: "Unknown reason")
       }
 
       if (response.code() !in 200..299) {
@@ -308,7 +313,8 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
         throw PushNotificationsAPIDeviceNotFound()
       }
       if (response.code() == 400) {
-        throw PushNotificationsAPIBadRequest()
+        val reason = response?.errorBody()?.let { safeExtractJsonError(it.string()).description }
+        throw PushNotificationsAPIBadRequest(reason ?: "Unknown reason")
       }
       if (response.code() == 401 || response.code() == 403) {
         val responseErrorBody = response?.errorBody()

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
@@ -415,7 +415,7 @@ class ServerSyncProcessHandler internal constructor(
           UserIdSet(
             userId = job.userId,
             pusherCallbackError = PusherCallbackError(
-                message = "Something went wrong. Please contact support@pusher.com.",
+                message = "Something went wrong: ${e.reason}. Please contact support@pusher.com.",
                 cause = e
             ))
       )


### PR DESCRIPTION
There is valuable information being sent to the server when a 400 is returned. Although it indicates a SDK implementation bug, we should still pass it through to our customers (which will later pass it down to support?).