### PR TITLE
Use Instance ID given in the notification for reporting purposes

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -42,6 +42,7 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
         }
 
         val reportEvent = DeliveryEvent(
+          instanceId = pusherData.instanceId,
           publishId = pusherData.publishId,
           deviceId = deviceId,
           userId = deviceStateStore.userId,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -61,6 +61,7 @@ class OpenNotificationActivity: Activity() {
                 }
 
                 val reportEvent = OpenEvent(
+                   instanceId = pusherData.instanceId,
                    publishId = pusherData.publishId,
                    deviceId = deviceId,
                    userId = deviceStateStore.userId,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingService.kt
@@ -17,6 +17,7 @@ enum class ReportEventType {
 
 sealed class ReportEvent(
   val event: ReportEventType,
+  val instanceId: String,
   val deviceId: String,
   val userId: String?,
   val publishId: String,
@@ -27,13 +28,15 @@ sealed class ReportEvent(
 )
 
 class OpenEvent (
+  instanceId: String,
   deviceId: String,
   userId: String?,
   publishId: String,
   timestampSecs: Long
-): ReportEvent(ReportEventType.Open, deviceId, userId, publishId, timestampSecs)
+): ReportEvent(ReportEventType.Open, instanceId, deviceId, userId, publishId, timestampSecs)
 
 class DeliveryEvent (
+  instanceId: String,
   deviceId: String,
   userId: String?,
   publishId: String,
@@ -41,4 +44,4 @@ class DeliveryEvent (
   appInBackground: Boolean,
   hasDisplayableContent: Boolean,
   hasData: Boolean
-): ReportEvent(ReportEventType.Delivery, deviceId, userId, publishId, timestampSecs, appInBackground, hasDisplayableContent, hasData)
+): ReportEvent(ReportEventType.Delivery, instanceId, deviceId, userId, publishId, timestampSecs, appInBackground, hasDisplayableContent, hasData)


### PR DESCRIPTION
If we want to support multiple instances, we need to know where it came from.