### PR TITLE
Release multi-instance support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.0] - 2019-11-13
+
+### Added
+- Support for multiple instances in the same application
+
 ## [1.4.6] - 2019-11-01
 
 ### Changed

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ClearAllStateTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ClearAllStateTest.kt
@@ -5,7 +5,7 @@ import android.support.test.runner.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.fcm.MessagingService
-import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.awaitility.core.ConditionTimeoutException
@@ -34,14 +34,14 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class ClearAllStateTest {
+  val instanceId = "00000000-1241-08e9-b379-377c32cd1e81"
+  val context = InstrumentationRegistry.getTargetContext()
+  val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
     return deviceStateStore.deviceId
   }
-
-  val context = InstrumentationRegistry.getTargetContext()
-  val instanceId = "00000000-1241-08e9-b379-377c32cd1e81"
-  val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   companion object {
     val errol = FakeErrol(8080, "a-really-long-secret-key-that-ends-with-hunter2")
@@ -56,7 +56,7 @@ class ClearAllStateTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
@@ -3,11 +3,10 @@ package com.example.pushnotificationsintegrationtests
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import com.google.firebase.iid.FirebaseInstanceId
-import com.pusher.pushnotifications.PushNotifications
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.SubscriptionsChangedListener
 import com.pusher.pushnotifications.fcm.MessagingService
-import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import org.awaitility.core.ConditionTimeoutException
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilNotNull
@@ -32,14 +31,15 @@ const val DEVICE_REGISTRATION_WAIT_SECS: Long = 15 // We need to wait for FCM to
  */
 @RunWith(AndroidJUnit4::class)
 class DeviceRegistrationTest {
-  fun getStoredDeviceId(): String? {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
-    return deviceStateStore.deviceId
-  }
-
   val context = InstrumentationRegistry.getTargetContext()
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e83"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
+
   companion object {
     val errol = FakeErrol(8080)
 
@@ -53,7 +53,7 @@ class DeviceRegistrationTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
@@ -163,14 +163,14 @@ class DeviceRegistrationTest {
     val getDeviceResponse = errolClient.getDevice(storedDeviceId!!)
     assertNotNull(getDeviceResponse)
 
-    val oldToken = errol.storage.devices[storedDeviceId]?.token
+    val oldToken = errol.getInstanceStorage(instanceId).devices[storedDeviceId]?.token
     assertThat(oldToken, `is`(not(equalTo(""))))
 
     FirebaseInstanceId.getInstance().deleteInstanceId()
 
     await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) until {
       // The server should have the new token now
-      val newToken = errol.storage.devices[storedDeviceId]?.token
+      val newToken = errol.getInstanceStorage(instanceId).devices[storedDeviceId]?.token
       newToken == oldToken && newToken != ""
     }
   }

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/FakeErrol.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/FakeErrol.kt
@@ -40,7 +40,6 @@ data class SetSubscriptionsRequest(
 
 class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter(port) {
   private val storage = mutableMapOf<String, FakeErrolStorage>()
-  private val instanceIdKey = "instanceId"
 
   fun getInstanceStorage(instanceId: String): FakeErrolStorage {
     return storage.getOrPut(instanceId, { FakeErrolStorage() })
@@ -54,7 +53,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     post("/instances/{instanceId}/devices/fcm") {
       entity(RegisterDeviceRequest::class) { registerDeviceRequest ->
         val device = FakeErrolDevice.New(registerDeviceRequest.token, mutableSetOf())
-        getInstanceStorage(params[instanceIdKey]!!).devices[device.id] = device
+        getInstanceStorage(params["instanceId"]!!).devices[device.id] = device
 
         complete(Response.Status.OK,
             NewDeviceResponse(id = device.id, initialInterestSet = emptySet()))
@@ -62,11 +61,11 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     }
 
     put("/instances/{instanceId}/devices/fcm/{deviceId}/token") {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device != null) {
         entity(RegisterDeviceRequest::class) { registerDeviceRequest ->
           val device = FakeErrolDevice.New(registerDeviceRequest.token, mutableSetOf())
-          getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]!!] = device.copy(token = registerDeviceRequest.token)
+          getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]!!] = device.copy(token = registerDeviceRequest.token)
 
           complete(Response.Status.OK)
         }
@@ -76,7 +75,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     }
 
     get("/instances/{instanceId}/devices/fcm/{deviceId}") {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device != null) {
         complete(Response.Status.OK, GetDeviceResponse(id = device.id, userId = device.userId, deviceMetadata = DeviceMetadata("", "")))
       } else {
@@ -85,9 +84,9 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     }
 
     delete("/instances/{instanceId}/devices/fcm/{deviceId}") {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device != null) {
-        getInstanceStorage(params[instanceIdKey]!!).devices -= params["deviceId"]!!
+        getInstanceStorage(params["instanceId"]!!).devices -= params["deviceId"]!!
         complete(Response.Status.OK)
       } else {
         complete(Response.Status.OK)
@@ -95,7 +94,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     }
 
     put("/instances/{instanceId}/devices/fcm/{deviceId}/user", fun NanoHTTPDRouter.Request.(): NanoHTTPD.Response {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device == null) {
         return complete(Response.Status.NOT_FOUND)
       }
@@ -110,7 +109,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
         val claims = Jwts.parser()
             .setSigningKey(Base64.getEncoder().encode(clusterKey.toByteArray()))
             .parseClaimsJws(jwt)
-        getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]!!] = device.copy(userId = claims.body.subject)
+        getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]!!] = device.copy(userId = claims.body.subject)
         complete(Response.Status.OK)
       } catch (e: Exception) {
         complete(Response.Status.BAD_REQUEST)
@@ -118,7 +117,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     })
 
     get("/instances/{instanceId}/devices/fcm/{deviceId}/interests") {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device != null) {
         complete(Response.Status.OK, GetInterestsResponse(interests = device.interests))
       } else {
@@ -127,7 +126,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     }
 
     post("/instances/{instanceId}/devices/fcm/{deviceId}/interests/{interest}") {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device != null) {
         device.interests.add(params["interest"]!!)
         complete(Response.Status.OK)
@@ -137,7 +136,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
     }
 
     delete("/instances/{instanceId}/devices/fcm/{deviceId}/interests/{interest}") {
-      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+      val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
       if (device != null) {
         device.interests.remove(params["interest"]!!)
         complete(Response.Status.OK)
@@ -148,7 +147,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
 
     put("/instances/{instanceId}/devices/fcm/{deviceId}/interests") {
       entity(SetSubscriptionsRequest::class) { setSubscriptions ->
-        val device = getInstanceStorage(params[instanceIdKey]!!).devices[params["deviceId"]]
+        val device = getInstanceStorage(params["instanceId"]!!).devices[params["deviceId"]]
         if (device != null) {
           device.interests.clear()
           device.interests.addAll(setSubscriptions.interests)

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/FakeErrol.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/FakeErrol.kt
@@ -22,7 +22,7 @@ data class FakeErrolDevice(
 }
 
 data class FakeErrolStorage(
-  val devices: MutableMap<String, FakeErrolDevice>
+  val devices: MutableMap<String, FakeErrolDevice> = mutableMapOf()
 )
 
 data class RegisterDeviceRequest(
@@ -39,29 +39,35 @@ data class SetSubscriptionsRequest(
 )
 
 class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter(port) {
-  val storage = FakeErrolStorage(mutableMapOf())
+  private val storage = mutableMapOf<String, FakeErrolStorage>()
+  private val instanceIdKey = "instanceId"
+  private val deviceIdKey = "deviceId"
+
+  fun getInstanceStorage(instanceId: String): FakeErrolStorage {
+    return storage.getOrPut(instanceId, { FakeErrolStorage() })
+  }
 
   init {
     start(NanoHTTPD.SOCKET_READ_TIMEOUT, false)
   }
 
   override fun setupRoutes() {
-    post("/instances/{instanceId}/devices/fcm") {
+    post("/instances/{$instanceIdKey}/devices/fcm") {
       entity(RegisterDeviceRequest::class) { registerDeviceRequest ->
         val device = FakeErrolDevice.New(registerDeviceRequest.token, mutableSetOf())
-        storage.devices[device.id] = device
+        getInstanceStorage(params[instanceIdKey]!!).devices[device.id] = device
 
         complete(Response.Status.OK,
             NewDeviceResponse(id = device.id, initialInterestSet = emptySet()))
       }
     }
 
-    put("/instances/{instanceId}/devices/fcm/{deviceId}/token") {
-      val device = storage.devices[params["deviceId"]]
+    put("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/token") {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device != null) {
         entity(RegisterDeviceRequest::class) { registerDeviceRequest ->
           val device = FakeErrolDevice.New(registerDeviceRequest.token, mutableSetOf())
-          storage.devices[params["deviceId"]!!] = device.copy(token = registerDeviceRequest.token)
+          getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]!!] = device.copy(token = registerDeviceRequest.token)
 
           complete(Response.Status.OK)
         }
@@ -70,8 +76,8 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
       }
     }
 
-    get("/instances/{instanceId}/devices/fcm/{deviceId}") {
-      val device = storage.devices[params["deviceId"]]
+    get("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}") {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device != null) {
         complete(Response.Status.OK, GetDeviceResponse(id = device.id, userId = device.userId, deviceMetadata = DeviceMetadata("", "")))
       } else {
@@ -79,18 +85,18 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
       }
     }
 
-    delete("/instances/{instanceId}/devices/fcm/{deviceId}") {
-      val device = storage.devices[params["deviceId"]]
+    delete("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}") {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device != null) {
-        storage.devices -= params["deviceId"]!!
+        getInstanceStorage(params[instanceIdKey]!!).devices -= params[deviceIdKey]!!
         complete(Response.Status.OK)
       } else {
         complete(Response.Status.OK)
       }
     }
 
-    put("/instances/{instanceId}/devices/fcm/{deviceId}/user", fun NanoHTTPDRouter.Request.(): NanoHTTPD.Response {
-      val device = storage.devices[params["deviceId"]]
+    put("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/user", fun NanoHTTPDRouter.Request.(): NanoHTTPD.Response {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device == null) {
         return complete(Response.Status.NOT_FOUND)
       }
@@ -105,15 +111,15 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
         val claims = Jwts.parser()
             .setSigningKey(Base64.getEncoder().encode(clusterKey.toByteArray()))
             .parseClaimsJws(jwt)
-        storage.devices[params["deviceId"]!!] = device.copy(userId = claims.body.subject)
+        getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]!!] = device.copy(userId = claims.body.subject)
         complete(Response.Status.OK)
       } catch (e: Exception) {
         complete(Response.Status.BAD_REQUEST)
       }
     })
 
-    get("/instances/{instanceId}/devices/fcm/{deviceId}/interests") {
-      val device = storage.devices[params["deviceId"]]
+    get("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/interests") {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device != null) {
         complete(Response.Status.OK, GetInterestsResponse(interests = device.interests))
       } else {
@@ -121,8 +127,8 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
       }
     }
 
-    post("/instances/{instanceId}/devices/fcm/{deviceId}/interests/{interest}") {
-      val device = storage.devices[params["deviceId"]]
+    post("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/interests/{interest}") {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device != null) {
         device.interests.add(params["interest"]!!)
         complete(Response.Status.OK)
@@ -131,8 +137,8 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
       }
     }
 
-    delete("/instances/{instanceId}/devices/fcm/{deviceId}/interests/{interest}") {
-      val device = storage.devices[params["deviceId"]]
+    delete("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/interests/{interest}") {
+      val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
       if (device != null) {
         device.interests.remove(params["interest"]!!)
         complete(Response.Status.OK)
@@ -141,9 +147,9 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
       }
     }
 
-    put("/instances/{instanceId}/devices/fcm/{deviceId}/interests") {
+    put("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/interests") {
       entity(SetSubscriptionsRequest::class) { setSubscriptions ->
-        val device = storage.devices[params["deviceId"]]
+        val device = getInstanceStorage(params[instanceIdKey]!!).devices[params[deviceIdKey]]
         if (device != null) {
           device.interests.clear()
           device.interests.addAll(setSubscriptions.interests)
@@ -155,7 +161,7 @@ class FakeErrol(port: Int, private val clusterKey: String = ""): NanoHTTPDRouter
       }
     }
 
-    put("/instances/{instanceId}/devices/fcm/{deviceId}/metadata") {
+    put("/instances/{$instanceIdKey}/devices/fcm/{$deviceIdKey}/metadata") {
       complete(Response.Status.OK)
     }
   }

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultiInstanceSupportTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultiInstanceSupportTest.kt
@@ -1,0 +1,339 @@
+package com.example.pushnotificationsintegrationtests
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.pusher.pushnotifications.BeamsCallback
+import com.pusher.pushnotifications.PushNotificationsInstance
+import com.pusher.pushnotifications.PusherCallbackError
+import com.pusher.pushnotifications.SubscriptionsChangedListener
+import com.pusher.pushnotifications.auth.TokenProvider
+import com.pusher.pushnotifications.fcm.MessagingService
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.awaitility.core.ConditionTimeoutException
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilNotNull
+import org.awaitility.kotlin.untilNull
+import org.awaitility.kotlin.until
+import org.hamcrest.CoreMatchers.*
+import org.junit.After
+import org.junit.AfterClass
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+import org.junit.Before
+import java.io.File
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class MultiInstanceSupportTest {
+  private val context = InstrumentationRegistry.getTargetContext()
+  private val instanceId1 = "00000000-1241-08e9-b379-377c32cd1e80"
+  private val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e82"
+  private val errolClient1 = ErrolAPI(instanceId1, "http://localhost:8080")
+  private val errolClient2 = ErrolAPI(instanceId2, "http://localhost:8080")
+
+
+  fun getStoredDeviceId(instanceId: String): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
+
+  companion object {
+    const val clusterSecretKey = "really-long-cluster-secret-key"
+    private val errol = FakeErrol(8080, clusterSecretKey)
+
+    @AfterClass
+    @JvmStatic
+    fun shutdownFakeErrol() {
+      errol.stop()
+    }
+  }
+
+  @Before
+  @After
+  fun wipeLocalState() {
+    fun wipe(instanceId: String) {
+      val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+
+      await.atMost(1, TimeUnit.SECONDS) until {
+        assertTrue(deviceStateStore.clear())
+
+        deviceStateStore.interests.size == 0 && deviceStateStore.deviceId == null
+      }
+
+      File(context.filesDir, "$instanceId.jobqueue").delete()
+    }
+    wipe(instanceId1)
+    wipe(instanceId2)
+  }
+
+  private fun assertStoredDeviceIdIsNotNull(instanceId: String) {
+    try {
+      await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) untilNotNull {
+        getStoredDeviceId(instanceId)
+      }
+    } catch (e: ConditionTimeoutException) {
+      // Maybe FCM is complaining in CI, so let's pretend to have a token now
+      MessagingService.onRefreshToken!!("fake-fcm-token")
+
+      await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) untilNotNull {
+        getStoredDeviceId(instanceId)
+      }
+    }
+  }
+
+  @Test
+  fun startingShouldGiveDifferentDeviceIds() {
+    // Start both instances
+    val pni1 = PushNotificationsInstance(context, instanceId1)
+    pni1.start()
+
+    val pni2 = PushNotificationsInstance(context, instanceId2)
+    pni2.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull(instanceId1)
+    assertStoredDeviceIdIsNotNull(instanceId2)
+
+    val storedDeviceId1 = getStoredDeviceId(instanceId1)
+    val storedDeviceId2 = getStoredDeviceId(instanceId2)
+
+    // and they are different
+    assertNotEquals(storedDeviceId1, storedDeviceId2)
+
+    // and the stored ids should match the server one
+    assertNotNull(errolClient1.getDevice(storedDeviceId1!!))
+    assertNotNull(errolClient2.getDevice(storedDeviceId2!!))
+  }
+
+  @Test
+  fun stoppingShouldNotAffectTheOther() {
+    // Start both instances
+    val pni1 = PushNotificationsInstance(context, instanceId1)
+    pni1.start()
+
+    val pni2 = PushNotificationsInstance(context, instanceId2)
+    pni2.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull(instanceId1)
+    assertStoredDeviceIdIsNotNull(instanceId2)
+
+    val storedDeviceId1 = getStoredDeviceId(instanceId1)
+    val storedDeviceId2 = getStoredDeviceId(instanceId2)
+
+    // and the stored ids should match the server one
+    assertNotNull(errolClient1.getDevice(storedDeviceId1!!))
+    assertNotNull(errolClient2.getDevice(storedDeviceId2!!))
+
+    pni1.stop()
+
+    // check the server no longer has device 1
+    await.atMost(3, TimeUnit.SECONDS) untilNull {
+      errolClient1.getDevice(storedDeviceId1)
+    }
+    // but device 2 is still there
+    assertNotNull(errolClient2.getDevice(storedDeviceId2))
+  }
+
+  @Test
+  fun interestSubscriptionsShouldNotAffectTheOther() {
+    // Start both instances
+    val pni1 = PushNotificationsInstance(context, instanceId1)
+    pni1.addDeviceInterest("zebra")
+    pni1.addDeviceInterest("panda")
+    pni1.start()
+
+    val pni2 = PushNotificationsInstance(context, instanceId2)
+    pni2.addDeviceInterest("donut")
+    pni2.addDeviceInterest("pizza")
+    pni2.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull(instanceId1)
+    assertStoredDeviceIdIsNotNull(instanceId2)
+
+    val storedDeviceId1 = getStoredDeviceId(instanceId1)
+    val storedDeviceId2 = getStoredDeviceId(instanceId2)
+
+    // and the stored ids should match the server one
+    assertNotNull(errolClient1.getDevice(storedDeviceId1!!))
+    assertNotNull(errolClient2.getDevice(storedDeviceId2!!))
+
+    // check the server has the same interests
+    await.atMost(3, TimeUnit.SECONDS) until {
+      errolClient1.getDeviceInterests(storedDeviceId1) == setOf("zebra", "panda")
+    }
+    await.atMost(3, TimeUnit.SECONDS) until {
+      errolClient2.getDeviceInterests(storedDeviceId2) == setOf("donut", "pizza")
+    }
+
+    assertThat(pni1.getDeviceInterests(), `is`(setOf("zebra", "panda")))
+    assertThat(pni2.getDeviceInterests(), `is`(setOf("donut", "pizza")))
+
+    pni1.addDeviceInterest("koala")
+    pni1.removeDeviceInterest("zebra")
+    pni2.addDeviceInterest("bagel")
+    pni2.removeDeviceInterest("donut")
+
+    await.atMost(3, TimeUnit.SECONDS) until {
+      errolClient1.getDeviceInterests(storedDeviceId1) == setOf("panda", "koala")
+    }
+    await.atMost(3, TimeUnit.SECONDS) until {
+      errolClient2.getDeviceInterests(storedDeviceId2) == setOf("pizza", "bagel")
+    }
+
+    assertThat(pni1.getDeviceInterests(), `is`(setOf("panda", "koala")))
+    assertThat(pni2.getDeviceInterests(), `is`(setOf("pizza", "bagel")))
+  }
+
+  @Test
+  fun setUserIdShouldNotAffectTheOther() {
+    // Create token provider
+    val aliceJWT = makeJWT(instanceId1, clusterSecretKey, "alice")
+    val bobJWT = makeJWT(instanceId2, clusterSecretKey, "bob")
+    val tokenProvider1 = StubTokenProvider(aliceJWT)
+    val tokenProvider2 = StubTokenProvider(bobJWT)
+
+    // Start both instances
+    val pni1 = PushNotificationsInstance(context, instanceId1)
+    pni1.start()
+
+    var successWasCalled1 = false
+    var failureWasCalled1 = false
+    pni1.setUserId("alice", tokenProvider1, object: BeamsCallback<Void, PusherCallbackError> {
+      override fun onSuccess(vararg values: Void) {
+        successWasCalled1 = true
+      }
+
+      override fun onFailure(error: PusherCallbackError) {
+        failureWasCalled1 = true
+      }
+    })
+
+    val pni2 = PushNotificationsInstance(context, instanceId2)
+    pni2.start()
+
+    var successWasCalled2 = false
+    var failureWasCalled2 = false
+    pni2.setUserId("bob", tokenProvider2, object: BeamsCallback<Void, PusherCallbackError> {
+      override fun onSuccess(vararg values: Void) {
+        successWasCalled2 = true
+      }
+
+      override fun onFailure(error: PusherCallbackError) {
+        failureWasCalled2 = true
+      }
+    })
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull(instanceId1)
+    assertStoredDeviceIdIsNotNull(instanceId2)
+
+    val storedDeviceId1 = getStoredDeviceId(instanceId1)
+    val storedDeviceId2 = getStoredDeviceId(instanceId2)
+
+    // and the stored ids should match the server one
+    assertNotNull(errolClient1.getDevice(storedDeviceId1!!))
+    assertNotNull(errolClient2.getDevice(storedDeviceId2!!))
+
+    // check the server has the same interests
+    await.atMost(3, TimeUnit.SECONDS) until {
+      errolClient1.getDevice(storedDeviceId1)?.userId == "alice"
+    }
+    await.atMost(3, TimeUnit.SECONDS) until {
+      errolClient2.getDevice(storedDeviceId2)?.userId == "bob"
+    }
+
+    // make sure the callbacks were correctly triggered
+    assertTrue(successWasCalled1)
+    assertFalse(failureWasCalled1)
+    assertTrue(successWasCalled2)
+    assertFalse(failureWasCalled2)
+  }
+
+  @Test
+  fun setOnDeviceInterestsChangedListenerDoesNotAffectTheOther() {
+    // Start both instances
+    val pni1 = PushNotificationsInstance(context, instanceId1)
+    pni1.addDeviceInterest("hello")
+    pni1.start()
+
+    val pni2 = PushNotificationsInstance(context, instanceId2)
+    pni2.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull(instanceId1)
+    assertStoredDeviceIdIsNotNull(instanceId2)
+
+    val storedDeviceId1 = getStoredDeviceId(instanceId1)
+    val storedDeviceId2 = getStoredDeviceId(instanceId2)
+
+    // and the stored ids should match the server one
+    assertNotNull(errolClient1.getDevice(storedDeviceId1!!))
+    assertNotNull(errolClient2.getDevice(storedDeviceId2!!))
+
+    var setOnSubscriptionsChangedListenerCalledCount1 = 0
+    var lastSetOnSubscriptionsChangedListenerCalledWithInterests1: Set<String>? = null
+    pni1.setOnDeviceInterestsChangedListener(object : SubscriptionsChangedListener {
+      override fun onSubscriptionsChanged(interests: Set<String>) {
+        setOnSubscriptionsChangedListenerCalledCount1++
+        lastSetOnSubscriptionsChangedListenerCalledWithInterests1 = interests
+      }
+    })
+    var setOnSubscriptionsChangedListenerCalledCount2 = 0
+    var lastSetOnSubscriptionsChangedListenerCalledWithInterests2: Set<String>? = null
+    pni2.setOnDeviceInterestsChangedListener(object : SubscriptionsChangedListener {
+      override fun onSubscriptionsChanged(interests: Set<String>) {
+        setOnSubscriptionsChangedListenerCalledCount2++
+        lastSetOnSubscriptionsChangedListenerCalledWithInterests2 = interests
+      }
+    })
+
+    pni1.setDeviceInterests(setOf("potato"))
+    assertThat(setOnSubscriptionsChangedListenerCalledCount1, `is`(equalTo(1)))
+    assertThat(setOnSubscriptionsChangedListenerCalledCount2, `is`(equalTo(0)))
+
+    assertThat(lastSetOnSubscriptionsChangedListenerCalledWithInterests1, `is`(equalTo(setOf("potato"))))
+    assertNull(lastSetOnSubscriptionsChangedListenerCalledWithInterests2)
+
+    pni2.setDeviceInterests(setOf("pasta"))
+    assertThat(setOnSubscriptionsChangedListenerCalledCount1, `is`(equalTo(1)))
+    assertThat(setOnSubscriptionsChangedListenerCalledCount2, `is`(equalTo(1)))
+
+    assertThat(lastSetOnSubscriptionsChangedListenerCalledWithInterests1, `is`(equalTo(setOf("potato"))))
+    assertThat(lastSetOnSubscriptionsChangedListenerCalledWithInterests2, `is`(equalTo(setOf("pasta"))))
+  }
+
+  private class StubTokenProvider(var jwt: String): TokenProvider {
+    override fun fetchToken(userId: String): String {
+      return jwt
+    }
+  }
+
+  private fun makeJWT(instanceId: String, secretKey: String, userId: String): String {
+    val iss = "https://$instanceId.pushnotifications.pusher.com"
+    val exp = LocalDateTime.now().plusDays(1)
+
+    val b64SecretKey = Base64.getEncoder().encode(secretKey.toByteArray())
+
+    return Jwts.builder()
+        .setSubject(userId)
+        .setIssuer(iss)
+        .setExpiration(Date.from(exp.toInstant(ZoneOffset.UTC)))
+        .signWith(SignatureAlgorithm.HS256, b64SecretKey)
+        .compact()
+  }
+}

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultipleClassInstancesTests.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultipleClassInstancesTests.kt
@@ -6,7 +6,7 @@ import android.support.test.runner.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.fcm.MessagingService
-import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.awaitility.core.ConditionTimeoutException
@@ -33,14 +33,14 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class MultipleClassInstancesTests {
-  fun getStoredDeviceId(): String? {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
-    return deviceStateStore.deviceId
-  }
-
   val context = InstrumentationRegistry.getTargetContext()
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e82"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
 
   companion object {
     val secretKey = "a-really-long-secret-key-that-ends-with-hunter2"
@@ -56,7 +56,7 @@ class MultipleClassInstancesTests {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())
@@ -138,8 +138,8 @@ class MultipleClassInstancesTests {
 
   @Test
   fun multipleInstantiationsOfPushNotificationsInstanceAreSupported() {
-    val pni1 = PushNotificationsInstance(context, "00000000-1241-08e9-b379-377c32cd1e01")
-    val pni2 = PushNotificationsInstance(context, "00000000-1241-08e9-b379-377c32cd1e01")
+    val pni1 = PushNotificationsInstance(context, instanceId)
+    val pni2 = PushNotificationsInstance(context, instanceId)
     pni1.start()
 
     assertStoredDeviceIdIsNotNull()

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/SetUserIdTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/SetUserIdTest.kt
@@ -5,7 +5,7 @@ import android.support.test.runner.AndroidJUnit4
 import com.pusher.pushnotifications.*
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.fcm.MessagingService
-import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
 import org.awaitility.core.ConditionTimeoutException
@@ -31,15 +31,15 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class SetUserIdTest {
-  fun getStoredDeviceId(): String? {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
-    return deviceStateStore.deviceId
-  }
-
   val context = InstrumentationRegistry.getTargetContext()
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e84"
   val userId = "alice"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
 
   companion object {
     val secretKey = "a-really-long-secret-key-that-ends-with-hunter2"
@@ -56,7 +56,7 @@ class SetUserIdTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())
@@ -89,7 +89,7 @@ class SetUserIdTest {
     val tokenProvider = StubTokenProvider(jwt)
 
     // Start the SDK
-    val pni = PushNotificationsInstance(context, "00000000-1241-08e9-b379-377c32cd1e00")
+    val pni = PushNotificationsInstance(context, instanceId)
     pni.start()
 
     // A device ID should have been stored

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StartTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StartTest.kt
@@ -1,0 +1,124 @@
+package com.example.pushnotificationsintegrationtests
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.pusher.pushnotifications.PushNotifications
+import com.pusher.pushnotifications.PushNotificationsInstance
+import com.pusher.pushnotifications.fcm.MessagingService
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
+import org.awaitility.core.ConditionTimeoutException
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilNotNull
+import org.awaitility.kotlin.untilNull
+import org.awaitility.kotlin.until
+import org.hamcrest.CoreMatchers.*
+import org.junit.After
+import org.junit.AfterClass
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.junit.Assert.*
+import org.junit.Before
+import java.io.File
+import java.lang.IllegalStateException
+import java.util.concurrent.TimeUnit
+import kotlin.test.asserter
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class StartTest {
+  val context = InstrumentationRegistry.getTargetContext()
+  val instanceId = "00000000-1241-08e9-b379-377c32cd1e80"
+  val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e81"
+  val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
+
+  companion object {
+    val errol = FakeErrol(8080)
+
+    @AfterClass
+    @JvmStatic
+    fun shutdownFakeErrol() {
+      errol.stop()
+    }
+  }
+
+  @Before
+  @After
+  fun wipeLocalState() {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+
+    await.atMost(1, TimeUnit.SECONDS) until {
+      assertTrue(deviceStateStore.clear())
+
+      deviceStateStore.interests.size == 0 && deviceStateStore.deviceId == null
+    }
+
+    File(context.filesDir, "$instanceId.jobqueue").delete()
+  }
+
+  private fun assertStoredDeviceIdIsNotNull() {
+    try {
+      await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) untilNotNull {
+        getStoredDeviceId()
+      }
+    } catch (e: ConditionTimeoutException) {
+      // Maybe FCM is complaining in CI, so let's pretend to have a token now
+      MessagingService.onRefreshToken!!("fake-fcm-token")
+
+      await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) untilNotNull {
+        getStoredDeviceId()
+      }
+    }
+  }
+
+  @Test
+  fun startShouldRegisterToBeams() {
+    // Start the SDK
+    PushNotifications.start(context, instanceId)
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull()
+    val storedDeviceId = getStoredDeviceId()
+
+    // and the stored id should match the server one
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun startMultipleInstancesWithSingletonThrowsException() {
+    PushNotifications.start(context, instanceId)
+    PushNotifications.start(context, instanceId2)
+  }
+
+  @Test
+  fun startMultipleTimesWithSameInstanceShouldBeIdempotent() {
+    // Start the SDK
+    PushNotifications.start(context, instanceId)
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull()
+    val storedDeviceId = getStoredDeviceId()
+
+    // and the stored id should match the server one
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+
+    // start the SDK again with the same instanceId
+    PushNotifications.start(context, instanceId)
+
+    assertStoredDeviceIdIsNotNull()
+    val storedDeviceId2 = getStoredDeviceId()
+
+    // check we have the same deviceId
+    assertEquals(storedDeviceId, storedDeviceId2)
+  }
+}

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
@@ -2,10 +2,9 @@ package com.example.pushnotificationsintegrationtests
 
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
-import com.pusher.pushnotifications.PushNotifications
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.fcm.MessagingService
-import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import org.awaitility.core.ConditionTimeoutException
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilNotNull
@@ -30,14 +29,14 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class StopTest {
-  fun getStoredDeviceId(): String? {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
-    return deviceStateStore.deviceId
-  }
-
   val context = InstrumentationRegistry.getTargetContext()
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e80"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
 
   companion object {
     val errol = FakeErrol(8080)
@@ -52,7 +51,7 @@ class StopTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/DeviceStateStoreTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/DeviceStateStoreTest.kt
@@ -1,0 +1,105 @@
+package com.example.pushnotificationsintegrationtests.internal
+
+import android.content.Context
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.After
+import org.junit.Assert.assertThat
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class DeviceStateStoreTest {
+  val context: Context = InstrumentationRegistry.getTargetContext()
+  val instanceId1 = "00000000-1241-08e9-b379-377c32cd1e80"
+  val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e81"
+
+  val deviceStateStore = DeviceStateStore(context)
+
+  @Before
+  @After
+  fun wipeLocalState() {
+    val deviceStateStore = DeviceStateStore(context)
+    await.atMost(1, TimeUnit.SECONDS) until {
+      assertTrue(deviceStateStore.clear())
+
+      deviceStateStore.instanceIds.size == 0
+    }
+  }
+
+  @Test
+  fun instanceIdsShouldRetrieveAndStoreInstancesCorrectly() {
+    assertThat(deviceStateStore.instanceIds, `is`(emptySet<String>()))
+
+    deviceStateStore.instanceIds = mutableSetOf(instanceId1)
+
+    assertThat(deviceStateStore.instanceIds, `is`(equalTo(mutableSetOf(instanceId1))))
+
+    // and we can add more instances to this set
+    deviceStateStore.instanceIds = deviceStateStore.instanceIds.apply { add(instanceId2) }
+
+    assertThat(deviceStateStore.instanceIds, `is`(equalTo(mutableSetOf(instanceId1, instanceId2))))
+  }
+
+  @Test
+  fun instanceIdsShouldNotHaveDuplicates() {
+    assertThat(deviceStateStore.instanceIds, `is`(emptySet<String>()))
+
+    deviceStateStore.instanceIds = deviceStateStore.instanceIds.apply { add(instanceId1) }
+    assertThat(deviceStateStore.instanceIds, `is`(equalTo(mutableSetOf(instanceId1))))
+
+    deviceStateStore.instanceIds = deviceStateStore.instanceIds.apply { add(instanceId1) }
+    assertThat(deviceStateStore.instanceIds, `is`(equalTo(mutableSetOf(instanceId1))))
+  }
+
+  @Test
+  fun previousInstanceGetMigratedToNewFormat() {
+    assertThat(deviceStateStore.instanceIds, `is`(emptySet<String>()))
+
+    val instanceDeviceStateStore = InstanceDeviceStateStore(context, "i-123")
+    assertTrue(instanceDeviceStateStore.clear())
+    Thread.sleep(1000)
+
+    val prefs = context.getSharedPreferences("com.pusher.pushnotifications.PushNotificationsInstance", Context.MODE_PRIVATE)
+    prefs.edit().putString("instanceId", "i-123").commit()
+
+    val oldInstance = InstanceDeviceStateStore(context, null)
+    oldInstance.deviceId = "old"
+    oldInstance.userId = "old"
+    oldInstance.FCMToken = "old"
+    oldInstance.osVersion = "old"
+    oldInstance.sdkVersion = "old"
+    oldInstance.interests = mutableSetOf("old")
+    oldInstance.serverConfirmedInterestsHash = "old"
+    oldInstance.startJobHasBeenEnqueued = true
+    oldInstance.setUserIdHasBeenCalledWith = "old"
+
+    val newDSS = DeviceStateStore(context)
+    assertThat(newDSS.instanceIds, `is`(mutableSetOf("i-123")))
+
+    val newIDSS = InstanceDeviceStateStore(context, "i-123")
+    assertTrue(newIDSS.deviceId == "old")
+    assertTrue(newIDSS.userId == "old")
+    assertTrue(newIDSS.FCMToken == "old")
+    assertTrue(newIDSS.osVersion == "old")
+    assertTrue(newIDSS.sdkVersion == "old")
+    assertTrue(newIDSS.interests == mutableSetOf("old"))
+    assertTrue(newIDSS.serverConfirmedInterestsHash == "old")
+    assertTrue(newIDSS.startJobHasBeenEnqueued)
+    assertTrue(newIDSS.setUserIdHasBeenCalledWith == "old")
+  }
+}

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/InstanceDeviceStateStoreTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/InstanceDeviceStateStoreTest.kt
@@ -1,0 +1,164 @@
+package com.example.pushnotificationsintegrationtests.internal
+
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class InstanceDeviceStateStoreTest {
+  val context = InstrumentationRegistry.getTargetContext()
+  val instanceId1 = "00000000-1241-08e9-b379-377c32cd1e80"
+  val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e81"
+
+  val idss1 = InstanceDeviceStateStore(context, instanceId1)
+  val idss2 = InstanceDeviceStateStore(context, instanceId2)
+
+  @Before
+  @After
+  fun wipeLocalState() {
+      assertTrue(idss1.clear())
+      assertTrue(idss2.clear())
+    await.atMost(1, TimeUnit.SECONDS) until {
+
+      idss1.deviceId == null &&
+          idss1.userId == null &&
+          idss1.FCMToken == null &&
+          idss1.osVersion == null &&
+          idss1.sdkVersion == null &&
+          idss1.interests.size == 0 &&
+          idss1.serverConfirmedInterestsHash == null &&
+          !idss1.startJobHasBeenEnqueued &&
+          idss1.setUserIdHasBeenCalledWith == null &&
+      idss2.deviceId == null &&
+          idss2.userId == null &&
+          idss2.FCMToken == null &&
+          idss2.osVersion == null &&
+          idss2.sdkVersion == null &&
+          idss2.interests.size == 0 &&
+          idss2.serverConfirmedInterestsHash == null &&
+          !idss2.startJobHasBeenEnqueued &&
+          idss2.setUserIdHasBeenCalledWith == null
+    }
+  }
+
+  @Test
+  fun deviceIdShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.deviceId)
+    idss1.deviceId = "d-123"
+    assertThat(idss1.deviceId, `is`(equalTo("d-123")))
+  }
+
+  @Test
+  fun userIdShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.userId)
+    idss1.userId = "alice"
+    assertThat(idss1.userId, `is`(equalTo("alice")))
+  }
+
+  @Test
+  fun FCMTokenShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.FCMToken)
+    idss1.FCMToken = "t-123"
+    assertThat(idss1.FCMToken, `is`(equalTo("t-123")))
+  }
+
+  @Test
+  fun osVersionShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.osVersion)
+    idss1.osVersion = "android-9"
+    assertThat(idss1.osVersion, `is`(equalTo("android-9")))
+  }
+
+  @Test
+  fun sdkVersionShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.sdkVersion)
+    idss1.sdkVersion = "1.2.3"
+    assertThat(idss1.sdkVersion, `is`(equalTo("1.2.3")))
+  }
+
+  @Test
+  fun interestsShouldRetrieveAndStoreCorrectly() {
+    assertThat(idss1.interests, `is`(emptySet<String>()))
+    idss1.interests = mutableSetOf("donuts")
+    assertThat(idss1.interests, `is`(mutableSetOf("donuts")))
+  }
+
+  @Test
+  fun serverConfirmedInterestsHashShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.serverConfirmedInterestsHash)
+    idss1.serverConfirmedInterestsHash = "a1b2c3d4e5"
+    assertThat(idss1.serverConfirmedInterestsHash, `is`(equalTo("a1b2c3d4e5")))
+  }
+
+  @Test
+  fun startJobHasBeenEnqueuedShouldRetrieveAndStoreCorrectly() {
+    assertFalse(idss1.startJobHasBeenEnqueued)
+    idss1.startJobHasBeenEnqueued = true
+    assertTrue(idss1.startJobHasBeenEnqueued)
+  }
+
+  @Test
+  fun setUserIdHasBeenCalledWithShouldRetrieveAndStoreCorrectly() {
+    assertNull(idss1.setUserIdHasBeenCalledWith)
+    idss1.setUserIdHasBeenCalledWith = "bob"
+    assertThat(idss1.setUserIdHasBeenCalledWith, `is`(equalTo("bob")))
+  }
+
+  @Test
+  fun twoInstancesDoNotInterfere() {
+    idss1.deviceId = "0"
+    idss1.userId = "0"
+    idss1.FCMToken = "0"
+    idss1.osVersion = "0"
+    idss1.sdkVersion = "0"
+    idss1.interests = mutableSetOf("0")
+    idss1.serverConfirmedInterestsHash = "0"
+    idss1.startJobHasBeenEnqueued = true
+    idss1.setUserIdHasBeenCalledWith = "0"
+
+    idss2.deviceId = "1"
+    idss2.userId = "1"
+    idss2.FCMToken = "1"
+    idss2.osVersion = "1"
+    idss2.sdkVersion = "1"
+    idss2.interests = mutableSetOf("1")
+    idss2.serverConfirmedInterestsHash = "1"
+    idss2.startJobHasBeenEnqueued = false
+    idss2.setUserIdHasBeenCalledWith = "1"
+
+    assertTrue(idss1.deviceId == "0")
+    assertTrue(idss1.userId == "0")
+    assertTrue(idss1.FCMToken == "0")
+    assertTrue(idss1.osVersion == "0")
+    assertTrue(idss1.sdkVersion == "0")
+    assertTrue(idss1.interests == mutableSetOf("0"))
+    assertTrue(idss1.serverConfirmedInterestsHash == "0")
+    assertTrue(idss1.startJobHasBeenEnqueued)
+    assertTrue(idss1.setUserIdHasBeenCalledWith == "0")
+
+    assertTrue(idss2.deviceId == "1")
+    assertTrue(idss2.userId == "1")
+    assertTrue(idss2.FCMToken == "1")
+    assertTrue(idss2.osVersion == "1")
+    assertTrue(idss2.sdkVersion == "1")
+    assertTrue(idss2.interests == mutableSetOf("1"))
+    assertTrue(idss2.serverConfirmedInterestsHash == "1")
+    assertTrue(idss2.startJobHasBeenEnqueued == false)
+    assertTrue(idss2.setUserIdHasBeenCalledWith == "1")
+  }
+}

--- a/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
+++ b/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
@@ -27,19 +27,20 @@ import java.lang.RuntimeException
 
 @RunWith(AndroidJUnit4::class)
 class ServerSyncProcessHandlerTest {
+  val instanceId = "000000-c1de-09b9-a8f6-2a22dbdd062a"
+
   @Before
   @After
   fun cleanup() {
-    val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
     Assert.assertTrue(deviceStateStore.clear())
     Assert.assertNull(deviceStateStore.deviceId)
     Assert.assertThat(deviceStateStore.interests.size, `is`(equalTo(0)))
   }
 
-  val instanceId = "000000-c1de-09b9-a8f6-2a22dbdd062a"
   private val mockServer = MockWebServer().apply { start() }
   private val api = PushNotificationsAPI(instanceId, mockServer.url("/").toString())
-  private val deviceStateStore = DeviceStateStore(InstrumentationRegistry.getTargetContext())
+  private val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
   val moshi = Moshi.Builder().add(ServerSyncJob.jsonAdapterFactory).build()
   val converter = MoshiConverter(moshi.adapter(ServerSyncJob::class.java))
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
@@ -26,8 +26,19 @@ public class PushNotifications {
      * is deemed better for your project.
      */
     public static PushNotificationsInstance start(Context context, String instanceId) {
-        instance = new PushNotificationsInstance(context, instanceId);
-        instance.start();
+        if (instance == null) {
+            instance = new PushNotificationsInstance(context, instanceId);
+            instance.start();
+        } else if (!instance.getInstanceId().equals(instanceId)) {
+            String errorMessage =
+                    "PushNotifications.start has been called before with a different instanceId! (before: "
+                            + instance.getInstanceId() + ", now: " + instanceId + ").\n"
+                            + "If you want to use multiple instanceIds use the `PushNotificationsInstance` class directly "
+                            + "e.g. `val pushNotifications1 = PushNotificationsInstance(context, instanceId)`\n"
+                            + "`pushNotifications1.start()`";
+            throw new IllegalStateException(errorMessage);
+        }
+
         return instance;
     }
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
@@ -1,5 +1,7 @@
 package com.pusher.pushnotifications;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import android.app.Activity;
@@ -13,7 +15,7 @@ import com.pusher.pushnotifications.fcm.MessagingService;
  */
 public class PushNotifications {
     private static PushNotificationsInstance instance;
-    protected static TokenProvider tokenProvider;
+    protected static Map<String, TokenProvider> tokenProvider = new HashMap<>();
 
     /**
      * Starts the PushNotification client and synchronizes the FCM device token with

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -112,7 +112,7 @@ class PushNotificationsInstance @JvmOverloads constructor(
           serverSyncEventHandler.sendMessage(Message.obtain().apply { obj = msg })
         },
         getTokenProvider = {
-          PushNotifications.tokenProvider
+          PushNotifications.tokenProvider[instanceId]
         }
     )
   }()
@@ -365,7 +365,7 @@ class PushNotificationsInstance @JvmOverloads constructor(
     if (tokenProvider == null) { // this can happen when using Java
       throw IllegalStateException("Token provider can't be null")
     }
-    PushNotifications.tokenProvider = tokenProvider
+    PushNotifications.tokenProvider[instanceId] = tokenProvider
 
     if (!startHasBeenCalledThisSession) {
       throw IllegalStateException("Start method must be called before setUserId")

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ApplicationLifecycle.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ApplicationLifecycle.kt
@@ -63,7 +63,7 @@ class PushNotificationsInitProvider: ContentProvider() {
   override fun onCreate(): Boolean {
     val deviceStateStore = DeviceStateStore(context)
 
-    deviceStateStore.instanceId?.let { instanceId ->
+    deviceStateStore.instanceIds.forEach { instanceId ->
       val pni = PushNotificationsInstance(context, instanceId)
       pni.onApplicationStarted()
     }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/DeviceStateStore.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/DeviceStateStore.kt
@@ -3,13 +3,54 @@ package com.pusher.pushnotifications.internal
 import android.content.Context
 
 class DeviceStateStore(context: Context) {
-  companion object {
-    private val deviceStateStores = mutableMapOf<String, DeviceStateStore>()
+  private val preferencesOldInstanceIdKey = "instanceId"
+  private val preferencesInstanceIdsKey = "instanceIds"
 
-    internal fun obtain(instanceId: String, context: Context): DeviceStateStore {
+  private val oldPreferences = context.getSharedPreferences(
+      "com.pusher.pushnotifications.PushNotificationsInstance", Context.MODE_PRIVATE)
+  private val preferences = context.getSharedPreferences(
+      "com.pusher.pushnotifications.PushNotificationsInstances", Context.MODE_PRIVATE)
+
+  init {
+    // perform migration of old instance configuration, if needed
+    val existingOldInstanceId = oldPreferences.getString(preferencesOldInstanceIdKey, null)
+    existingOldInstanceId?.let { instanceId ->
+      val oldInstanceDSS = InstanceDeviceStateStore(context, null)
+      val newInstanceDSS = InstanceDeviceStateStore(context, instanceId)
+
+      newInstanceDSS.deviceId = oldInstanceDSS.deviceId
+      newInstanceDSS.userId = oldInstanceDSS.userId
+      newInstanceDSS.FCMToken = oldInstanceDSS.FCMToken
+      newInstanceDSS.osVersion = oldInstanceDSS.osVersion
+      newInstanceDSS.sdkVersion = oldInstanceDSS.sdkVersion
+      newInstanceDSS.interests = oldInstanceDSS.interests
+      newInstanceDSS.serverConfirmedInterestsHash = oldInstanceDSS.serverConfirmedInterestsHash
+      newInstanceDSS.startJobHasBeenEnqueued = oldInstanceDSS.startJobHasBeenEnqueued
+      newInstanceDSS.setUserIdHasBeenCalledWith = oldInstanceDSS.setUserIdHasBeenCalledWith
+
+      instanceIds = instanceIds.apply { add(instanceId) }
+      preferences.edit().remove(preferencesOldInstanceIdKey).apply()
+      oldInstanceDSS.clear()
+    }
+  }
+
+  var instanceIds: MutableSet<String>
+    // We need to clone the set we get from shared preferences because mutating it is not permitted
+    // by the Android SDK
+    get() = preferences.getStringSet(preferencesInstanceIdsKey, mutableSetOf<String>()).toMutableSet()
+    set(value) = preferences.edit().putStringSet(preferencesInstanceIdsKey, value).apply()
+
+  fun clear() = preferences.edit().clear().commit()
+}
+
+class InstanceDeviceStateStore(context: Context, val instanceId: String?) {
+  companion object {
+    private val deviceStateStores = mutableMapOf<String, InstanceDeviceStateStore>()
+
+    internal fun obtain(instanceId: String, context: Context): InstanceDeviceStateStore {
       return synchronized(deviceStateStores) {
         deviceStateStores.getOrPut(instanceId) {
-          DeviceStateStore(context)
+          InstanceDeviceStateStore(context, instanceId)
         }
       }
     }
@@ -18,7 +59,6 @@ class DeviceStateStore(context: Context) {
   private val preferencesDeviceIdKey = "deviceId"
   private val preferencesUserIdKey = "userId"
   private val preferencesFCMTokenKey = "fcmToken"
-  private val preferencesInstanceIdKey = "instanceId"
   private val preferencesOSVersionKey = "osVersion"
   private val preferencesSDKVersionKey = "sdkVersion"
   private val preferencesInterestsKey = "interests"
@@ -26,13 +66,16 @@ class DeviceStateStore(context: Context) {
   private val startJobHasBeenEnqueuedKey = "startJobHasBeenEnqueued"
   private val setUserIdHasBeenCalledWithKey = "setUserIdHasBeenCalledWith"
 
+  private fun sharedPreferencesName(instanceId: String?): String {
+    return if (instanceId == null) {
+      // special case to handle the migration of an old instance configuration
+      "com.pusher.pushnotifications.PushNotificationsInstance"
+    } else {
+      "com.pusher.pushnotifications.${instanceId}.PushNotificationsInstance"
+    }
+  }
 
-  private val preferences = context.getSharedPreferences(
-    "com.pusher.pushnotifications.PushNotificationsInstance", Context.MODE_PRIVATE)
-
-  var instanceId: String?
-    get() = preferences.getString(preferencesInstanceIdKey, null)
-    set(value) = preferences.edit().putString(preferencesInstanceIdKey, value).apply()
+  private val preferences = context.getSharedPreferences(sharedPreferencesName(instanceId), Context.MODE_PRIVATE)
 
   var deviceId: String?
     get() = preferences.getString(preferencesDeviceIdKey, null)

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ServerSyncHandler.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.*
 
 class ServerSyncHandler private constructor(
     private val api: PushNotificationsAPI,
-    private val deviceStateStore: DeviceStateStore,
+    private val deviceStateStore: InstanceDeviceStateStore,
     private val jobQueue: PersistentJobQueue<ServerSyncJob>,
     private val handleServerSyncEvent: (ServerSyncEvent) -> Unit,
     private val getTokenProvider: () -> TokenProvider?,
@@ -63,7 +63,7 @@ class ServerSyncHandler private constructor(
     internal fun obtain(
         instanceId: String,
         api: PushNotificationsAPI,
-        deviceStateStore: DeviceStateStore,
+        deviceStateStore: InstanceDeviceStateStore,
         secureFileDir: File,
         handleServerSyncEvent: (ServerSyncEvent) -> Unit,
         getTokenProvider: () -> TokenProvider?
@@ -119,7 +119,7 @@ class ServerSyncHandler private constructor(
 
 class ServerSyncProcessHandler internal constructor(
     private val api: PushNotificationsAPI,
-    private val deviceStateStore: DeviceStateStore,
+    private val deviceStateStore: InstanceDeviceStateStore,
     private val jobQueue: PersistentJobQueue<ServerSyncJob>,
     private val handleServerSyncEvent: (ServerSyncEvent) -> Unit,
     private val getTokenProvider: () -> TokenProvider?,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -10,6 +10,7 @@ import com.pusher.pushnotifications.featureflags.FeatureFlag
 import com.pusher.pushnotifications.featureflags.FeatureFlagManager
 import com.pusher.pushnotifications.internal.AppActivityLifecycleCallbacks
 import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.DeliveryEvent
 
@@ -33,7 +34,7 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
           return
         }
 
-        val deviceStateStore = DeviceStateStore(context)
+        val deviceStateStore = InstanceDeviceStateStore(context, pusherData.instanceId)
 
         val deviceId = deviceStateStore.deviceId
         if (deviceId == null) {

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -42,6 +42,7 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
         }
 
         val reportEvent = DeliveryEvent(
+          instanceId = pusherData.instanceId,
           publishId = pusherData.publishId,
           deviceId = deviceId,
           userId = deviceStateStore.userId,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -7,6 +7,7 @@ import com.firebase.jobdispatcher.*
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
 import com.pusher.pushnotifications.internal.DeviceStateStore
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.OpenEvent
 
@@ -48,11 +49,11 @@ class OpenNotificationActivity: Activity() {
 
         intent?.getStringExtra("pusher")?.let { pusherDataJson ->
             try {
-                val deviceStateStore = DeviceStateStore(applicationContext)
                 val gson = Gson()
                 val pusherData = gson.fromJson(pusherDataJson, PusherMetadata::class.java)
                 log.i("Got a valid pusher message.")
 
+                val deviceStateStore = InstanceDeviceStateStore(applicationContext, pusherData.instanceId)
                 val deviceId = deviceStateStore.deviceId
                 if (deviceId == null) {
                     log.e("Failed to get device ID (device ID not stored) - Skipping open tracking.")

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -61,6 +61,7 @@ class OpenNotificationActivity: Activity() {
                 }
 
                 val reportEvent = OpenEvent(
+                   instanceId = pusherData.instanceId,
                    publishId = pusherData.publishId,
                    deviceId = deviceId,
                    userId = deviceStateStore.userId,

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingService.kt
@@ -17,6 +17,7 @@ enum class ReportEventType {
 
 sealed class ReportEvent(
   val event: ReportEventType,
+  val instanceId: String,
   val deviceId: String,
   val userId: String?,
   val publishId: String,
@@ -27,13 +28,15 @@ sealed class ReportEvent(
 )
 
 class OpenEvent (
+  instanceId: String,
   deviceId: String,
   userId: String?,
   publishId: String,
   timestampSecs: Long
-): ReportEvent(ReportEventType.Open, deviceId, userId, publishId, timestampSecs)
+): ReportEvent(ReportEventType.Open, instanceId, deviceId, userId, publishId, timestampSecs)
 
 class DeliveryEvent (
+  instanceId: String,
   deviceId: String,
   userId: String?,
   publishId: String,
@@ -41,4 +44,4 @@ class DeliveryEvent (
   appInBackground: Boolean,
   hasDisplayableContent: Boolean,
   hasData: Boolean
-): ReportEvent(ReportEventType.Delivery, deviceId, userId, publishId, timestampSecs, appInBackground, hasDisplayableContent, hasData)
+): ReportEvent(ReportEventType.Delivery, instanceId, deviceId, userId, publishId, timestampSecs, appInBackground, hasDisplayableContent, hasData)

--- a/pushnotifications/src/test/java/com/pusher/pushnotifications/internal/DeviceStateStoreTest.kt
+++ b/pushnotifications/src/test/java/com/pusher/pushnotifications/internal/DeviceStateStoreTest.kt
@@ -25,122 +25,22 @@ class DeviceStateStoreTest {
   }
 
   @Test
-  fun `instanceId is retrieved correctly`() {
-    `when`(sharedPrefs.getString("instanceId", null))
-        .thenReturn(null)
-        .thenReturn("i-123")
-
-    Assert.assertNull(testDeviceStateStore.instanceId)
-    Assert.assertThat(testDeviceStateStore.instanceId, `is`(equalTo("i-123")))
-  }
-
-  @Test
-  fun `instanceId is stored correctly`() {
-    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
-    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putString("instanceId", "i-123")).thenReturn(mockEditor)
-    doNothing().`when`(mockEditor).apply()
-
-    testDeviceStateStore.instanceId = "i-123"
-  }
-
-  @Test
-  fun `deviceId is retrieved correctly`() {
-    `when`(sharedPrefs.getString("deviceId", null))
-        .thenReturn(null)
-        .thenReturn("i-123")
-
-    Assert.assertNull(testDeviceStateStore.deviceId)
-    Assert.assertThat(testDeviceStateStore.deviceId, `is`(equalTo("i-123")))
-  }
-
-  @Test
-  fun `deviceId is stored correctly`() {
-    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
-    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putString("deviceId", "i-123")).thenReturn(mockEditor)
-    doNothing().`when`(mockEditor).apply()
-
-    testDeviceStateStore.deviceId = "i-123"
-  }
-
-  @Test
-  fun `FCMToken is retrieved correctly`() {
-    `when`(sharedPrefs.getString("fcmToken", null))
-        .thenReturn(null)
-        .thenReturn("i-123")
-
-    Assert.assertNull(testDeviceStateStore.FCMToken)
-    Assert.assertThat(testDeviceStateStore.FCMToken, `is`(equalTo("i-123")))
-  }
-
-  @Test
-  fun `FCMToken is stored correctly`() {
-    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
-    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putString("fcmToken", "i-123")).thenReturn(mockEditor)
-    doNothing().`when`(mockEditor).apply()
-
-    testDeviceStateStore.FCMToken = "i-123"
-  }
-
-  @Test
-  fun `osVersion is retrieved correctly`() {
-    `when`(sharedPrefs.getString("osVersion", null))
-        .thenReturn(null)
-        .thenReturn("i-123")
-
-    Assert.assertNull(testDeviceStateStore.osVersion)
-    Assert.assertThat(testDeviceStateStore.osVersion, `is`(equalTo("i-123")))
-  }
-
-  @Test
-  fun `osVersion is stored correctly`() {
-    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
-    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putString("osVersion", "i-123")).thenReturn(mockEditor)
-    doNothing().`when`(mockEditor).apply()
-
-    testDeviceStateStore.osVersion = "i-123"
-  }
-
-  @Test
-  fun `sdkVersion is retrieved correctly`() {
-    `when`(sharedPrefs.getString("sdkVersion", null))
-        .thenReturn(null)
-        .thenReturn("i-123")
-
-    Assert.assertNull(testDeviceStateStore.sdkVersion)
-    Assert.assertThat(testDeviceStateStore.sdkVersion, `is`(equalTo("i-123")))
-  }
-
-  @Test
-  fun `sdkVersion is stored correctly`() {
-    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
-    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putString("sdkVersion", "i-123")).thenReturn(mockEditor)
-    doNothing().`when`(mockEditor).apply()
-
-    testDeviceStateStore.sdkVersion = "i-123"
-  }
-
-  @Test
-  fun `interestsSet is retrieved correctly`() {
-    `when`(sharedPrefs.getStringSet("interests", mutableSetOf<String>()))
+  fun `instanceIds is retrieved correctly`() {
+    `when`(sharedPrefs.getStringSet("instanceIds", mutableSetOf<String>()))
         .thenReturn(mutableSetOf<String>())
-        .thenReturn(mutableSetOf("hello"))
+        .thenReturn(mutableSetOf("i-123"))
 
-    Assert.assertThat(testDeviceStateStore.interests, `is`(emptySet<String>()))
-    Assert.assertThat(testDeviceStateStore.interests, `is`(equalTo(mutableSetOf("hello"))))
+    Assert.assertThat(testDeviceStateStore.instanceIds, `is`(emptySet<String>()))
+    Assert.assertThat(testDeviceStateStore.instanceIds, `is`(equalTo(mutableSetOf("i-123"))))
   }
 
   @Test
-  fun `interestsSet is stored correctly`() {
+  fun `instanceIds is stored correctly`() {
     val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
     `when`(sharedPrefs.edit()).thenReturn(mockEditor)
-    `when`(mockEditor.putStringSet("interests", mutableSetOf("hello"))).thenReturn(mockEditor)
+    `when`(mockEditor.putStringSet("instanceIds", mutableSetOf("i-123"))).thenReturn(mockEditor)
     doNothing().`when`(mockEditor).apply()
 
-    testDeviceStateStore.interests = mutableSetOf("hello")
+    testDeviceStateStore.instanceIds = mutableSetOf("i-123")
   }
 }

--- a/pushnotifications/src/test/java/com/pusher/pushnotifications/internal/InstanceDeviceStateStoreTest.kt
+++ b/pushnotifications/src/test/java/com/pusher/pushnotifications/internal/InstanceDeviceStateStoreTest.kt
@@ -1,0 +1,126 @@
+package com.pusher.pushnotifications.internal
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.junit.Before
+import org.mockito.Mockito.doNothing
+
+class InstanceDeviceStateStoreTest {
+  private val context: Context = Mockito.mock(Context::class.java)
+  private val sharedPrefs = Mockito.mock(SharedPreferences::class.java)
+  private lateinit var testInstanceDeviceStateStore: InstanceDeviceStateStore
+
+  @Before
+  fun before() {
+    `when`(context.getSharedPreferences("com.pusher.pushnotifications.i-123.PushNotificationsInstance", Context.MODE_PRIVATE))
+        .thenReturn(sharedPrefs)
+
+    this.testInstanceDeviceStateStore = InstanceDeviceStateStore(context, "i-123")
+  }
+
+  @Test
+  fun `deviceId is retrieved correctly`() {
+    `when`(sharedPrefs.getString("deviceId", null))
+        .thenReturn(null)
+        .thenReturn("i-123")
+
+    Assert.assertNull(testInstanceDeviceStateStore.deviceId)
+    Assert.assertThat(testInstanceDeviceStateStore.deviceId, `is`(equalTo("i-123")))
+  }
+
+  @Test
+  fun `deviceId is stored correctly`() {
+    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
+    `when`(mockEditor.putString("deviceId", "i-123")).thenReturn(mockEditor)
+    doNothing().`when`(mockEditor).apply()
+
+    testInstanceDeviceStateStore.deviceId = "i-123"
+  }
+
+  @Test
+  fun `FCMToken is retrieved correctly`() {
+    `when`(sharedPrefs.getString("fcmToken", null))
+        .thenReturn(null)
+        .thenReturn("i-123")
+
+    Assert.assertNull(testInstanceDeviceStateStore.FCMToken)
+    Assert.assertThat(testInstanceDeviceStateStore.FCMToken, `is`(equalTo("i-123")))
+  }
+
+  @Test
+  fun `FCMToken is stored correctly`() {
+    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
+    `when`(mockEditor.putString("fcmToken", "i-123")).thenReturn(mockEditor)
+    doNothing().`when`(mockEditor).apply()
+
+    testInstanceDeviceStateStore.FCMToken = "i-123"
+  }
+
+  @Test
+  fun `osVersion is retrieved correctly`() {
+    `when`(sharedPrefs.getString("osVersion", null))
+        .thenReturn(null)
+        .thenReturn("i-123")
+
+    Assert.assertNull(testInstanceDeviceStateStore.osVersion)
+    Assert.assertThat(testInstanceDeviceStateStore.osVersion, `is`(equalTo("i-123")))
+  }
+
+  @Test
+  fun `osVersion is stored correctly`() {
+    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
+    `when`(mockEditor.putString("osVersion", "i-123")).thenReturn(mockEditor)
+    doNothing().`when`(mockEditor).apply()
+
+    testInstanceDeviceStateStore.osVersion = "i-123"
+  }
+
+  @Test
+  fun `sdkVersion is retrieved correctly`() {
+    `when`(sharedPrefs.getString("sdkVersion", null))
+        .thenReturn(null)
+        .thenReturn("i-123")
+
+    Assert.assertNull(testInstanceDeviceStateStore.sdkVersion)
+    Assert.assertThat(testInstanceDeviceStateStore.sdkVersion, `is`(equalTo("i-123")))
+  }
+
+  @Test
+  fun `sdkVersion is stored correctly`() {
+    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
+    `when`(mockEditor.putString("sdkVersion", "i-123")).thenReturn(mockEditor)
+    doNothing().`when`(mockEditor).apply()
+
+    testInstanceDeviceStateStore.sdkVersion = "i-123"
+  }
+
+  @Test
+  fun `interestsSet is retrieved correctly`() {
+    `when`(sharedPrefs.getStringSet("interests", mutableSetOf<String>()))
+        .thenReturn(mutableSetOf<String>())
+        .thenReturn(mutableSetOf("hello"))
+
+    Assert.assertThat(testInstanceDeviceStateStore.interests, `is`(emptySet<String>()))
+    Assert.assertThat(testInstanceDeviceStateStore.interests, `is`(equalTo(mutableSetOf("hello"))))
+  }
+
+  @Test
+  fun `interestsSet is stored correctly`() {
+    val mockEditor = Mockito.mock(SharedPreferences.Editor::class.java)
+    `when`(sharedPrefs.edit()).thenReturn(mockEditor)
+    `when`(mockEditor.putStringSet("interests", mutableSetOf("hello"))).thenReturn(mockEditor)
+    doNothing().`when`(mockEditor).apply()
+
+    testInstanceDeviceStateStore.interests = mutableSetOf("hello")
+  }
+}


### PR DESCRIPTION
This PR is releasing the following PRs:

- #92 Use Instance ID given in the notification for reporting purposes
- #93 Make Internal Device State Store scoped per Instance
- #94 Make token provider scoped per instance
- #95 Enforce singleton to use one instanceId

Plus updating the changelog.