### PR TITLE
Make notification reporting more resilient

### DIFF
--- a/pushnotifications-integration-tests/build.gradle
+++ b/pushnotifications-integration-tests/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
+    implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
+
     implementation project(':pushnotifications')
     lintChecks project(':pushnotifications-lint')
 

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ReportingTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ReportingTest.kt
@@ -1,0 +1,231 @@
+package com.example.pushnotificationsintegrationtests
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.support.test.InstrumentationRegistry
+import android.support.test.runner.AndroidJUnit4
+import com.firebase.jobdispatcher.*
+import com.pusher.pushnotifications.*
+import com.pusher.pushnotifications.fcm.MessagingService
+import com.pusher.pushnotifications.internal.AppActivityLifecycleCallbacks
+import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
+import com.pusher.pushnotifications.reporting.ReportingJobService
+import com.pusher.pushnotifications.reporting.api.DeliveryEvent
+import org.awaitility.core.ConditionTimeoutException
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.awaitility.kotlin.untilNotNull
+import org.junit.*
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * See [testing documentation](http://d.android.com/tools/testing).
+ */
+@RunWith(AndroidJUnit4::class)
+class ReportingTest {
+  val context = InstrumentationRegistry.getTargetContext()
+  val instanceId = "00000000-1241-08e9-b379-377c32cd1e84"
+  val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
+  val targetCtx: Context = InstrumentationRegistry.getTargetContext()
+
+  fun getStoredDeviceId(): String? {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    return deviceStateStore.deviceId
+  }
+
+  companion object {
+    val secretKey = "a-really-long-secret-key-that-ends-with-hunter2"
+
+    val errol = FakeErrol(8080, secretKey)
+
+    @AfterClass
+    @JvmStatic
+    fun shutdownFakeErrol() {
+      errol.stop()
+    }
+  }
+
+  @Before
+  @After
+  fun wipeLocalState() {
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+
+    await.atMost(1, TimeUnit.SECONDS) until {
+      assertTrue(deviceStateStore.clear())
+
+      deviceStateStore.interests.size == 0 && deviceStateStore.deviceId == null
+    }
+
+    File(context.filesDir, "$instanceId.jobqueue").delete()
+  }
+
+  @Before
+  @After
+  fun wipeServerReportedNotifications() {
+    errol.getInstanceEventsStorage(instanceId).clear()
+  }
+
+  private fun assertStoredDeviceIdIsNotNull() {
+    try {
+      await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) untilNotNull {
+        getStoredDeviceId()
+      }
+    } catch (e: ConditionTimeoutException) {
+      // Maybe FCM is complaining in CI, so let's pretend to have a token now
+      MessagingService.onRefreshToken!!("fake-fcm-token")
+
+      await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) untilNotNull {
+        getStoredDeviceId()
+      }
+    }
+  }
+
+  @Test
+  @Ignore("The job dispatcher will schedule the job but it isn't triggered within a reasonable timeframe")
+  fun aNotificationSentFromPusherShouldBeReportedTestBroken() {
+    // Start the SDK
+    val pni = PushNotificationsInstance(context, instanceId)
+    pni.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull()
+    val storedDeviceId = getStoredDeviceId()
+
+    // and the device id should exist in the server
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+
+    // send a notification
+    val i = Intent()
+    i.action = "com.google.android.c2dm.intent.RECEIVE"
+    i.`package` = targetCtx.packageName
+
+    val bundle = Bundle()
+    bundle.putString("google.delivered_priority", "high")
+    bundle.putLong("google.sent_time", 1574938426317)
+    bundle.putLong("google.ttl", 2419200)
+    bundle.putString("google.original_priority", "high")
+    bundle.putString("gcm.notification.e", "1")
+    bundle.putString("pusher", """{"instanceId":"$instanceId","hasDisplayableContent":true,"publishId":"pubid-e3c82c34-667b-4969-9509-ff59dfbe328a"}""")
+    i.replaceExtras(bundle)
+
+    targetCtx.sendBroadcast(i)
+
+    await.atMost(90, TimeUnit.MINUTES) until {
+      errol.getInstanceEventsStorage(instanceId).any { event ->
+        event.publishId == "pubid-e3c82c34-667b-4969-9509-ff59dfbe328a"
+      }
+    }
+  }
+
+  @Test
+  fun aNotificationSentFromPusherShouldBeReported() {
+    // Start the SDK
+    val pni = PushNotificationsInstance(context, instanceId)
+    pni.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull()
+    val storedDeviceId = getStoredDeviceId()
+
+    // and the device id should exist in the server
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+
+    val reportEvent = DeliveryEvent(
+        instanceId = instanceId,
+        publishId = "pubid-e3c82c34-667b-4969-9509-ff59dfbe328a",
+        deviceId = storedDeviceId,
+        userId = "alice",
+        timestampSecs = Math.round(System.currentTimeMillis() / 1000.0),
+        appInBackground = AppActivityLifecycleCallbacks.appInBackground(),
+        hasDisplayableContent = false,
+        hasData = true
+    )
+
+    val bundledEvent = ReportingJobService.toBundle(reportEvent)
+
+    val job =
+        FirebaseJobDispatcher(GooglePlayDriver(context)).newJobBuilder()
+            .setService(ReportingJobService::class.java)
+            .setConstraints(Constraint.ON_ANY_NETWORK)
+            .setTag("pusher.delivered.publishId=pubid-e3c82c34-667b-4969-9509-ff59dfbe328a")
+            .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
+            .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
+            .setExtras(bundledEvent)
+            .build()
+
+    class ReportingJobServiceWithContext : ReportingJobService() {
+      init {
+        attachBaseContext(context)
+      }
+    }
+
+    val reportingJobService = ReportingJobServiceWithContext()
+
+    assertTrue(reportingJobService.onStartJob(job))
+
+    await.atMost(5, TimeUnit.SECONDS) until {
+      errol.getInstanceEventsStorage(instanceId).any { event ->
+        event.publishId == "pubid-e3c82c34-667b-4969-9509-ff59dfbe328a"
+      }
+    }
+  }
+
+  @Test
+  fun aNotificationSentWithOldSDKVersionShouldNotBeReported() {
+    // Start the SDK
+    val pni = PushNotificationsInstance(context, instanceId)
+    pni.start()
+
+    // A device ID should have been stored
+    assertStoredDeviceIdIsNotNull()
+    val storedDeviceId = getStoredDeviceId()
+
+    // and the device id should exist in the server
+    assertNotNull(errolClient.getDevice(storedDeviceId!!))
+
+    val reportEvent = DeliveryEvent(
+        instanceId = instanceId,
+        publishId = "pubid-e3c82c34-667b-4969-9509-ff59dfbe328a",
+        deviceId = storedDeviceId,
+        userId = "alice",
+        timestampSecs = Math.round(System.currentTimeMillis() / 1000.0),
+        appInBackground = AppActivityLifecycleCallbacks.appInBackground(),
+        hasDisplayableContent = false,
+        hasData = true
+    )
+
+    val bundledEvent = ReportingJobService.toBundle(reportEvent)
+    // old sdk didn't bundle in the instance id, so it will be missing
+    bundledEvent.remove("InstanceId")
+
+    val job =
+        FirebaseJobDispatcher(GooglePlayDriver(context)).newJobBuilder()
+            .setService(ReportingJobService::class.java)
+            .setConstraints(Constraint.ON_ANY_NETWORK)
+            .setTag("pusher.delivered.publishId=pubid-e3c82c34-667b-4969-9509-ff59dfbe328a")
+            .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
+            .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
+            .setExtras(bundledEvent)
+            .build()
+
+    class ReportingJobServiceWithContext : ReportingJobService() {
+      init {
+        attachBaseContext(context)
+      }
+    }
+
+    val reportingJobService = ReportingJobServiceWithContext()
+
+    assertFalse(reportingJobService.onStartJob(job))
+
+    Thread.sleep(1000)
+    assertEquals(errol.getInstanceEventsStorage(instanceId).size, 0)
+  }
+}
+

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ReportingTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ReportingTest.kt
@@ -106,6 +106,9 @@ class ReportingTest {
     i.`package` = targetCtx.packageName
 
     val bundle = Bundle()
+    // grabbing all the fields from an actual push notification which will include
+    // undocumented and Google FCM specific keys. These are left here to ensure that
+    // our tests are more realistic and our reporting isn't affected by their presence
     bundle.putString("google.delivered_priority", "high")
     bundle.putLong("google.sent_time", 1574938426317)
     bundle.putLong("google.ttl", 2419200)
@@ -161,6 +164,7 @@ class ReportingTest {
 
     class ReportingJobServiceWithContext : ReportingJobService() {
       init {
+        // Android Studio might render the following function as red, but it works.
         attachBaseContext(context)
       }
     }
@@ -177,7 +181,7 @@ class ReportingTest {
   }
 
   @Test
-  fun aNotificationSentWithOldSDKVersionShouldNotBeReported() {
+  fun migrationWithJobScheduledWithMissingInstanceIdDoesNotCrashButLosesTheReport() {
     // Start the SDK
     val pni = PushNotificationsInstance(context, instanceId)
     pni.start()

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ReportingTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ReportingTest.kt
@@ -22,11 +22,6 @@ import org.junit.runner.RunWith
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-/**
- * Instrumented test, which will execute on an Android device.
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
 @RunWith(AndroidJUnit4::class)
 class ReportingTest {
   val context = InstrumentationRegistry.getTargetContext()

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -66,8 +66,9 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
         dispatcher.mustSchedule(job)
         log.i("Notification reporting successfully scheduled.")
 
-      } catch (_: JsonSyntaxException) {
-        // TODO: Add client-side reporting
+      } catch (e: Exception) {
+        log.w("Something went wrong when trying to schedule a notification report: $e")
+        // TODO: Add client-side reporting to better track these situations
       }
     }
   }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -64,6 +64,8 @@ class FCMMessageReceiver : WakefulBroadcastReceiver() {
           .build()
 
         dispatcher.mustSchedule(job)
+        log.i("Notification reporting successfully scheduled.")
+
       } catch (_: JsonSyntaxException) {
         // TODO: Add client-side reporting
       }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -64,15 +64,20 @@ open class ReportingJobService: JobService() {
     }
 
     fun fromBundle(bundle: Bundle): ReportEvent? {
-      val eventType = bundle.getString(BUNDLE_EVENT_TYPE_KEY) ?: return null
-
+      val eventType = bundle.getString(BUNDLE_EVENT_TYPE_KEY)
       when (ReportEventType.valueOf(eventType)) {
         ReportEventType.Delivery -> {
+          // returning `null` if the instance id is missing because it's possible that
+          // we are processing a bundle that was created with an old SDK version that
+          // didn't had this key. Our migration strategy is to drop the reporting
+          // as it's (a) a rare one-time transition and (b) it's a best effort feature.
+          val instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY) ?: return null
+
           return DeliveryEvent(
-            instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY) ?: return null,
-            deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY) ?: return null,
+            instanceId = instanceId,
+            deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
             userId = bundle.getString(BUNDLE_USER_ID_KEY),
-            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY) ?: return null,
+            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
             timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
             appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
             hasDisplayableContent = bundle.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY),
@@ -80,11 +85,17 @@ open class ReportingJobService: JobService() {
           )
         }
         ReportEventType.Open -> {
+          // returning `null` if the instance id is missing because it's possible that
+          // we are processing a bundle that was created with an old SDK version that
+          // didn't had this key. Our migration strategy is to drop the reporting
+          // as it's (a) a rare one-time transition and (b) it's a best effort feature.
+          val instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY) ?: return null
+
           return OpenEvent(
-            instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY) ?: return null,
-            deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY) ?: return null,
+            instanceId = instanceId,
+            deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
             userId = bundle.getString(BUNDLE_USER_ID_KEY),
-            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY) ?: return null,
+            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
             timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
           )
         }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -4,151 +4,148 @@ import android.os.Bundle
 import com.firebase.jobdispatcher.JobParameters
 import com.firebase.jobdispatcher.JobService
 import com.google.gson.annotations.SerializedName
-import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.api.OperationCallbackNoArgs
 import com.pusher.pushnotifications.internal.SDKConfiguration
+import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.*
 
 data class PusherMetadata(
-  val instanceId: String,
-  val publishId: String,
-  val clickAction: String?,
-  @SerializedName("hasDisplayableContent") private val _hasDisplayableContent: Boolean?,
-  @SerializedName("hasData") private val _hasData: Boolean?
+        val instanceId: String,
+        val publishId: String,
+        val clickAction: String?,
+        @SerializedName("hasDisplayableContent") private val _hasDisplayableContent: Boolean?,
+        @SerializedName("hasData") private val _hasData: Boolean?
 ) {
-  val hasDisplayableContent: Boolean
-    get() = _hasDisplayableContent ?: false
+    val hasDisplayableContent: Boolean
+        get() = _hasDisplayableContent ?: false
 
-  val hasData: Boolean
-    get() = _hasData ?: false
+    val hasData: Boolean
+        get() = _hasData ?: false
 }
 
 // Marking it as `open` to facilitate testing, but it's not meant to be extended otherwise
 open class ReportingJobService: JobService() {
-  companion object {
-    private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
-    private const val BUNDLE_INSTANCE_ID_KEY = "InstanceId"
-    private const val BUNDLE_DEVICE_ID_KEY = "DeviceId"
-    private const val BUNDLE_USER_ID_KEY = "UserId"
-    private const val BUNDLE_PUBLISH_ID_KEY = "PublishId"
-    private const val BUNDLE_TIMESTAMP_KEY = "Timestamp"
-    private const val BUNDLE_APP_IN_BACKGROUND_KEY = "AppInBackground"
-    private const val BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY = "HasDisplayableContent"
-    private const val BUNDLE_HAS_DATA_KEY = "HasData"
+    companion object {
+        private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
+        private const val BUNDLE_INSTANCE_ID_KEY = "InstanceId"
+        private const val BUNDLE_DEVICE_ID_KEY = "DeviceId"
+        private const val BUNDLE_USER_ID_KEY = "UserId"
+        private const val BUNDLE_PUBLISH_ID_KEY = "PublishId"
+        private const val BUNDLE_TIMESTAMP_KEY = "Timestamp"
+        private const val BUNDLE_APP_IN_BACKGROUND_KEY = "AppInBackground"
+        private const val BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY = "HasDisplayableContent"
+        private const val BUNDLE_HAS_DATA_KEY = "HasData"
 
-    fun toBundle(reportEvent: ReportEvent): Bundle {
-      val b = Bundle()
-      when (reportEvent) {
-        is DeliveryEvent -> {
-          b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
-          b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
-          b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
-          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
-          b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
-          b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
-          b.putBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, reportEvent.appInBackground!!)
-          b.putBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY, reportEvent.hasDisplayableContent!!)
-          b.putBoolean(BUNDLE_HAS_DATA_KEY, reportEvent.hasData!!)
-        }
-
-        is OpenEvent -> {
-          b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
-          b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
-          b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
-          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
-          b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
-          b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
-        }
-      }
-
-      return b
-    }
-
-    fun fromBundle(bundle: Bundle): ReportEvent? {
-      val instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY)
-      if (instanceId == null) {
-        // it's possible that we are processing a bundle that was created with an old SDK
-        // version that didn't had this key. Our migration strategy is to drop the reporting
-        // as it's (a) a rare one-time transition and (b) it's a best effort feature.
-        return null
-      }
-
-      val eventType = bundle.getString(BUNDLE_EVENT_TYPE_KEY)
-      when (ReportEventType.valueOf(eventType)) {
-        ReportEventType.Delivery -> {
-
-          return DeliveryEvent(
-            instanceId = instanceId,
-            deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
-            userId = bundle.getString(BUNDLE_USER_ID_KEY),
-            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
-            timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
-            appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
-            hasDisplayableContent = bundle.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY),
-            hasData = bundle.getBoolean(BUNDLE_HAS_DATA_KEY)
-          )
-        }
-        ReportEventType.Open -> {
-          return OpenEvent(
-            instanceId = instanceId,
-            deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
-            userId = bundle.getString(BUNDLE_USER_ID_KEY),
-            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
-            timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
-          )
-        }
-      }
-    }
-  }
-
-  private val log = Logger.get(this::class)
-
-  override fun onStartJob(params: JobParameters?): Boolean {
-    log.i("Received reporting job.")
-
-    try {
-      params?.let {
-        val extras = it.extras
-        if (extras != null) {
-          val reportEvent = fromBundle(extras)
-          if (reportEvent != null) {
-            reportEvent.deviceId
-
-            ReportingAPI(reportEvent.instanceId, SDKConfiguration(applicationContext).overrideHostURL).submit(
-                reportEvent = reportEvent,
-                operationCallback = object : OperationCallbackNoArgs {
-                  override fun onSuccess() {
-                    log.i("Successfully submitted report.")
-                    jobFinished(params, false)
-                  }
-
-                  override fun onFailure(t: Throwable) {
-                    log.w("Failed submitted report.", t)
-                    val shouldRetry = t !is UnrecoverableRuntimeException
-
-                    jobFinished(params, shouldRetry)
-                  }
+        fun toBundle(reportEvent: ReportEvent): Bundle {
+            val b = Bundle()
+            when (reportEvent) {
+                is DeliveryEvent -> {
+                    b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
+                    b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
+                    b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+                    b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
+                    b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
+                    b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
+                    b.putBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, reportEvent.appInBackground!!)
+                    b.putBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY, reportEvent.hasDisplayableContent!!)
+                    b.putBoolean(BUNDLE_HAS_DATA_KEY, reportEvent.hasData!!)
                 }
-            )
-          } else {
-            log.w("Incorrect start of service: extras bundle is partially corrupted.")
-            return false
-          }
-        } else {
-          log.w("Incorrect start of service: extras bundle is missing.")
-          return false
+
+                is OpenEvent -> {
+                    b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
+                    b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
+                    b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+                    b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
+                    b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
+                    b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
+                }
+            }
+
+            return b
         }
-      }
-    } catch (e: Exception) {
-      log.w("Something went wrong when trying to send a notification report: $e")
-      // TODO: Add client-side reporting to better track these situations
-      return false
+
+        private class MissingInstanceIdException : RuntimeException()
+
+        private fun fromBundle(bundle: Bundle): ReportEvent {
+            val instanceId : String? = bundle.getString(BUNDLE_INSTANCE_ID_KEY)
+            @Suppress("FoldInitializerAndIfToElvis")
+            if (instanceId == null) {
+                // It's possible that we are processing a bundle that was created with an old SDK
+                // version that didn't had this key. Our migration strategy is to drop the reporting
+                // as it's (a) a rare one-time transition and (b) it's a best effort feature.
+                // Throwing a specific exception (to not compromise the code design -- nullable return
+                // type) which will be caught on calling this private fun.
+                throw MissingInstanceIdException()
+            }
+
+            val event = ReportEventType.valueOf(bundle.getString(BUNDLE_EVENT_TYPE_KEY))
+            when (event) {
+                ReportEventType.Delivery -> {
+                    return DeliveryEvent(
+                            instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY),
+                            deviceId = instanceId,
+                            userId = bundle.getString(BUNDLE_USER_ID_KEY),
+                            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
+                            timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
+                            appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
+                            hasDisplayableContent = bundle.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY),
+                            hasData = bundle.getBoolean(BUNDLE_HAS_DATA_KEY)
+                    )
+                }
+                ReportEventType.Open -> {
+                    return OpenEvent(
+                            instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY),
+                            deviceId = instanceId,
+                            userId = bundle.getString(BUNDLE_USER_ID_KEY),
+                            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
+                            timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
+                    )
+                }
+            }
+        }
     }
 
-    return true // A background job was started
-  }
+    private val log = Logger.get(this::class)
 
-  override fun onStopJob(params: JobParameters?): Boolean {
-    return true // Answers the question: "Should this job be retried?"
-  }
+    override fun onStartJob(params: JobParameters?): Boolean {
+        params?.let {
+            val extras = it.extras
+
+            if (extras != null) {
+                try {
+                    val reportEvent = fromBundle(extras)
+                    reportEvent.deviceId
+
+                    ReportingAPI(reportEvent.instanceId, SDKConfiguration(applicationContext).overrideHostURL).submit(
+                            reportEvent = reportEvent,
+                            operationCallback = object: OperationCallbackNoArgs {
+                                override fun onSuccess() {
+                                    log.v("Successfully submitted report.")
+                                    jobFinished(params, false)
+                                }
+
+                                override fun onFailure(t: Throwable) {
+                                    log.w("Failed submitted report.", t)
+                                    val shouldRetry = t !is UnrecoverableRuntimeException
+
+                                    jobFinished(params, shouldRetry)
+                                }
+                            }
+                    )
+                } catch (e : MissingInstanceIdException) {
+                    log.w("Missing instance id, can't report.")
+                    return false
+                }
+            } else {
+                log.w("Incorrect start of service: extras bundle is missing.")
+                return false
+            }
+        }
+
+        return true // A background job was started
+    }
+
+    override fun onStopJob(params: JobParameters?): Boolean {
+        return true // Answers the question: "Should this job be retried?"
+    }
 }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -106,7 +106,7 @@ class ReportingJobService: JobService() {
               reportEvent = reportEvent,
               operationCallback = object : OperationCallbackNoArgs {
                 override fun onSuccess() {
-                  log.v("Successfully submitted report.")
+                  log.i("Successfully submitted report.")
                   jobFinished(params, false)
                 }
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -64,14 +64,17 @@ open class ReportingJobService: JobService() {
     }
 
     fun fromBundle(bundle: Bundle): ReportEvent? {
+      val instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY)
+      if (instanceId == null) {
+        // it's possible that we are processing a bundle that was created with an old SDK
+        // version that didn't had this key. Our migration strategy is to drop the reporting
+        // as it's (a) a rare one-time transition and (b) it's a best effort feature.
+        return null
+      }
+
       val eventType = bundle.getString(BUNDLE_EVENT_TYPE_KEY)
       when (ReportEventType.valueOf(eventType)) {
         ReportEventType.Delivery -> {
-          // returning `null` if the instance id is missing because it's possible that
-          // we are processing a bundle that was created with an old SDK version that
-          // didn't had this key. Our migration strategy is to drop the reporting
-          // as it's (a) a rare one-time transition and (b) it's a best effort feature.
-          val instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY) ?: return null
 
           return DeliveryEvent(
             instanceId = instanceId,
@@ -85,12 +88,6 @@ open class ReportingJobService: JobService() {
           )
         }
         ReportEventType.Open -> {
-          // returning `null` if the instance id is missing because it's possible that
-          // we are processing a bundle that was created with an old SDK version that
-          // didn't had this key. Our migration strategy is to drop the reporting
-          // as it's (a) a rare one-time transition and (b) it's a best effort feature.
-          val instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY) ?: return null
-
           return OpenEvent(
             instanceId = instanceId,
             deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -5,8 +5,8 @@ import com.firebase.jobdispatcher.JobParameters
 import com.firebase.jobdispatcher.JobService
 import com.google.gson.annotations.SerializedName
 import com.pusher.pushnotifications.logging.Logger
-import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.api.OperationCallbackNoArgs
+import com.pusher.pushnotifications.internal.SDKConfiguration
 import com.pusher.pushnotifications.reporting.api.*
 
 data class PusherMetadata(
@@ -104,7 +104,7 @@ class ReportingJobService: JobService() {
         if (reportEvent != null) {
           reportEvent.deviceId
 
-          ReportingAPI(reportEvent.instanceId).submit(
+          ReportingAPI(reportEvent.instanceId, SDKConfiguration(applicationContext).overrideHostURL).submit(
               reportEvent = reportEvent,
               operationCallback = object : OperationCallbackNoArgs {
                 override fun onSuccess() {

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -23,6 +23,7 @@ data class PusherMetadata(
     get() = _hasData ?: false
 }
 
+// Marking it as `open` to facilitate testing, but it's not meant to be extended otherwise
 open class ReportingJobService: JobService() {
   companion object {
     private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -23,7 +23,7 @@ data class PusherMetadata(
     get() = _hasData ?: false
 }
 
-class ReportingJobService: JobService() {
+open class ReportingJobService: JobService() {
   companion object {
     private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
     private const val BUNDLE_INSTANCE_ID_KEY = "InstanceId"

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -95,6 +95,8 @@ class ReportingJobService: JobService() {
   private val log = Logger.get(this::class)
 
   override fun onStartJob(params: JobParameters?): Boolean {
+    log.i("Received reporting job.")
+
     params?.let {
       val extras = it.extras
       if (extras != null) {

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingAPI.kt
@@ -12,8 +12,9 @@ import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-class ReportingAPI(private val instanceId: String) {
-  private val baseUrl = "https://$instanceId.pushnotifications.pusher.com/reporting_api/v2/"
+class ReportingAPI(private val instanceId: String, overrideHostURL: String?) {
+  private val baseUrl =
+      overrideHostURL ?: "https://$instanceId.pushnotifications.pusher.com/reporting_api/v2/"
 
   private val gson = Gson()
 


### PR DESCRIPTION
## Why?

We had a customer report with the following stack trace:
```
Fatal Exception: java.lang.IllegalStateException: bundle.getString(BUNDLE_INSTANCE_ID_KEY) must not be null
       at com.pusher.pushnotifications.reporting.ReportingJobService$Companion.fromBundle(ReportingJobService.java:71)
       at com.pusher.pushnotifications.reporting.ReportingJobService.onStartJob(ReportingJobService.java:100)
       at com.firebase.jobdispatcher.JobService$2.run(JobService.java:164)
       at android.os.Handler.handleCallback(Handler.java:873)
       at android.os.Handler.dispatchMessage(Handler.java:99)
       at android.os.Looper.loop(Looper.java:201)
       at android.app.ActivityThread.main(ActivityThread.java:6810)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:873)
```

I'm not sure when this can happen, but these operations are best-effort, so we should fail silently if something is occasionally wrong for some reason.