### PR TITLE
Work around missing instance id migration for reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 22 14:42:05 BST 2019
+#Mon Dec 02 10:31:17 GMT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -80,23 +80,23 @@ class ReportingJobService: JobService() {
       when (event) {
         ReportEventType.Delivery -> {
           return DeliveryEvent(
-            instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY),
-            deviceId = instanceId,
-            userId = bundle.getString(BUNDLE_USER_ID_KEY),
-            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
-            timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
-            appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
-            hasDisplayableContent = bundle.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY),
-            hasData = bundle.getBoolean(BUNDLE_HAS_DATA_KEY)
+                  instanceId = instanceId,
+                  deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
+                  userId = bundle.getString(BUNDLE_USER_ID_KEY),
+                  publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
+                  timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
+                  appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
+                  hasDisplayableContent = bundle.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY),
+                  hasData = bundle.getBoolean(BUNDLE_HAS_DATA_KEY)
           )
         }
         ReportEventType.Open -> {
           return OpenEvent(
-            instanceId = bundle.getString(BUNDLE_INSTANCE_ID_KEY),
-            deviceId = instanceId,
-            userId = bundle.getString(BUNDLE_USER_ID_KEY),
-            publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
-            timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
+                  instanceId = instanceId,
+                  deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
+                  userId = bundle.getString(BUNDLE_USER_ID_KEY),
+                  publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
+                  timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
           )
         }
       }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -64,6 +64,7 @@ class ReportingJobService: JobService() {
 
     private class MissingInstanceIdException : RuntimeException()
 
+    @Throws(MissingInstanceIdException::class)
     private fun fromBundle(bundle: Bundle): ReportEvent {
       val instanceId : String? = bundle.getString(BUNDLE_INSTANCE_ID_KEY)
       @Suppress("FoldInitializerAndIfToElvis")


### PR DESCRIPTION
This is based off #97:

We had a customer report a fatal issue where their notification bundle did not provide an instanceid. If we don't receive an instanceid we should not crash, we should log an error, and not report the notification.
