### PR TITLE
Fix device state store unit test

### DIFF
--- a/pushnotifications/src/test/java/com/pusher/pushnotifications/internal/DeviceStateStoreTest.kt
+++ b/pushnotifications/src/test/java/com/pusher/pushnotifications/internal/DeviceStateStoreTest.kt
@@ -20,6 +20,8 @@ class DeviceStateStoreTest {
   fun before() {
     `when`(context.getSharedPreferences("com.pusher.pushnotifications.PushNotificationsInstance", Context.MODE_PRIVATE))
         .thenReturn(sharedPrefs)
+    `when`(context.getSharedPreferences("com.pusher.pushnotifications.PushNotificationsInstances", Context.MODE_PRIVATE))
+            .thenReturn(sharedPrefs)
 
     this.testDeviceStateStore = DeviceStateStore(context)
   }


### PR DESCRIPTION
This test failed because it depended on the previous way of using the device state store test - we need to return a migrated device state store as well as the "old" device state store