### PR TITLE
Proguard rule for Moshi reflect

### DIFF
--- a/pushnotifications/proguard-rules.pro
+++ b/pushnotifications/proguard-rules.pro
@@ -32,3 +32,6 @@
 -keep class com.pusher.pushnotifications.** {
   *;
 }
+
+## Moshi reflect (https://github.com/square/moshi/issues/345#issuecomment-325413124)
+-keep class kotlin.Metadata { *; }


### PR DESCRIPTION
https://github.com/pusher/push-notifications-android/pull/101 enables moshi-kotlin reflection adapter which crashes if the kotlin.Metadata annotation is removed by proguard.

More background about this at: https://github.com/square/moshi/issues/345


Stacktrace of the crash:
```
Caused by: java.lang.IllegalArgumentException: Cannot serialize abstract class com.pusher.pushnotifications.internal.ServerSyncJob
        at k.f.a.e0.a.b.a(:33)
        at k.f.a.a0.a(:5)
        at k.f.a.a0.a()
        at k.f.a.a0.a()
        at com.pusher.pushnotifications.internal.ServerSyncHandler$Companion.obtain$pushnotifications_release(:5)
        at com.pusher.pushnotifications.PushNotificationsInstance$serverSyncHandler$1.invoke()
        at com.pusher.pushnotifications.PushNotificationsInstance$serverSyncHandler$1.invoke()
        at com.pusher.pushnotifications.PushNotificationsInstance.<init>()
        at com.pusher.pushnotifications.PushNotifications.start()
        at e.a.a.b.w.c(:1)
        at ai.memory.dewo.mainactivity.MainActivity.onCreate(:9)
        at android.app.Activity.performCreate(Activity.java:6251)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1107)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2369)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476) 
        at android.app.ActivityThread.-wrap11(ActivityThread.java) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344) 
        at android.os.Handler.dispatchMessage(Handler.java:102) 
        at android.os.Looper.loop(Looper.java:148) 
        at android.app.ActivityThread.main(ActivityThread.java:5417) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 
```