### PR TITLE
Add support for opening deep link when opening notification

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -2,6 +2,7 @@ package com.pusher.pushnotifications.reporting
 
 import android.app.Activity
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import com.firebase.jobdispatcher.*
 import com.google.gson.Gson
@@ -29,6 +30,15 @@ class OpenNotificationActivity: Activity() {
         }
 
         i.replaceExtras(bundle)
+
+        val link: String
+
+        link = i.getStringExtra("link")
+
+        if(link != null) {
+          log.i("Got URI for action $link")
+          i.setData(Uri.parse(link))
+        }
 
         // We need to clear the activity stack so that this activity doesn't show up when customers
         // are debugging.


### PR DESCRIPTION
This PR adds support so that we can send an optional link with the notification so that we can navigate to a specific screen when opening an app using the library.