### PR TITLE
Single OkHttpClient in ReportingAPI

### DIFF
--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingAPI.kt
@@ -17,11 +17,6 @@ class ReportingAPI(private val instanceId: String) {
 
   private val gson = Gson()
 
-  private val client =
-    OkHttpClient.Builder()
-      .addInterceptor(PusherLibraryHeaderInterceptor())
-      .build()
-
   private val service =
     Retrofit.Builder()
       .baseUrl(baseUrl)
@@ -53,5 +48,13 @@ class ReportingAPI(private val instanceId: String) {
       instanceId = instanceId,
       reportingRequest = reportEvent
     ).enqueue(callback)
+  }
+
+
+  companion object {
+    val client: OkHttpClient =
+      OkHttpClient.Builder()
+        .addInterceptor(PusherLibraryHeaderInterceptor())
+        .build()
   }
 }


### PR DESCRIPTION
Recently`OutOfMemoryError` exceptions occurred when receiving high amount of PusherBeams notifications in our app.

```
Fatal Exception: java.lang.OutOfMemoryError: Could not allocate JNI Env
       at java.lang.Thread.nativeCreate(Thread.java)
       at java.lang.Thread.start(Thread.java:730)
       at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:941)
       at java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1359)
       at okhttp3.ConnectionPool.put(ConnectionPool.java:153)
       at okhttp3.OkHttpClient$1.put(OkHttpClient.java:167)
       ...
       at com.pusher.pushnotifications.api.PusherLibraryHeaderInterceptor.intercept(PusherLibraryHeaderInterceptor.kt:13)
       ...
```

According to this [stackoverflow post](https://stackoverflow.com/questions/49069297/okhttpclient-connection-pool-size-dilemma) each new okHttpClient has his own connection pool.

By instantiating only one instance of the client future request add up in the same connection pool and  runs memory efficient.