### PR TITLE
add null check for intial interests while registering device with FCM

### DIFF
--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
-        versionName "1.6.2"
+        versionName "1.6.3"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
@@ -141,6 +141,9 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
 
       val responseBody = response?.body()
       if (responseBody != null && response.code() in 200..299) {
+        if (responseBody.initialInterestSet==null || responseBody.id==null){
+          throw PushNotificationsAPIException("device id or initial interests is null")
+        }
         return RegisterDeviceResult(
             deviceId = responseBody.id,
             initialInterests = responseBody.initialInterestSet)


### PR DESCRIPTION
Fix for issue https://github.com/pusher/push-notifications-android/issues/115

On first device register we are getting null `initialInterests`. We are fixing this on backend but at the same time it makes sense to add the check here.