### PR TITLE
Remove job dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.7-alpha] - 2021-05-20
+## [1.7.0-alpha] - 2021-05-20
 - Migrate to AndroidX
 - Update Firebase dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.7.0-alpha.1] - 2021-06-01
-- Introduce Android WorkManager in place of Firebase JobDispatcher
-
-## [1.7.0-alpha] - 2021-05-20
+## [1.7.0] - 2021-06-07
 - Migrate to AndroidX
 - Update Firebase dependencies
+- Introduce Android WorkManager in place of Firebase JobDispatcher
 
 ## [1.6.2] - 2020-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7-alpha] - 2021-05-20
+- Migrate to AndroidX
+- Update Firebase dependencies
+
 ## [1.6.2] - 2020-01-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [1.7.0] - 2021-06-07
+
+### Fixed
+- Fix issue #112 and #117
+
+### Changed
 - Migrate to AndroidX
 - Update Firebase dependencies
 - Introduce Android WorkManager in place of Firebase JobDispatcher

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.7.0-alpha.1] - 2021-06-01
+- Introduce Android WorkManager in place of Firebase JobDispatcher
+
 ## [1.7.0-alpha] - 2021-05-20
 - Migrate to AndroidX
 - Update Firebase dependencies

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ buildscript {
 
 ### Update your app level gradle config
 
+If using firebase-messaging version below 22.0.0:
 ```
 dependencies {
     ...
@@ -34,6 +35,20 @@ dependencies {
     implementation 'com.google.firebase:firebase-core:16.0.9'
     implementation 'com.google.firebase:firebase-messaging:18.0.0'
     implementation 'com.pusher:push-notifications-android:1.6.2'
+}
+
+// Add this line to the end of the file
+apply plugin: 'com.google.gms.google-services'
+```
+
+If using firebase-messaging 22.0.0 and above:
+```
+dependencies {
+    ...
+
+    // Add these lines
+    implementation 'com.google.firebase:firebase-messaging:22.0.0'
+    implementation "com.google.firebase:firebase-iid:21.1.0"
 }
 
 // Add this line to the end of the file

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-core:16.0.9'
     implementation 'com.google.firebase:firebase-messaging:18.0.0'
-    implementation 'com.pusher:push-notifications-android:1.7.0-alpha.1'
+    implementation 'com.pusher:push-notifications-android:1.7.0'
 }
 
 // Add this line to the end of the file
@@ -49,7 +49,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-messaging:22.0.0'
     implementation "com.google.firebase:firebase-iid:21.1.0"
-    implementation 'com.pusher:push-notifications-android:1.7.0-alpha.1'
+    implementation 'com.pusher:push-notifications-android:1.7.0'
 }
 
 // Add this line to the end of the file

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-core:16.0.9'
     implementation 'com.google.firebase:firebase-messaging:18.0.0'
-    implementation 'com.pusher:push-notifications-android:1.7.0-alpha'
+    implementation 'com.pusher:push-notifications-android:1.7.0-alpha.1'
 }
 
 // Add this line to the end of the file
@@ -49,7 +49,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-messaging:22.0.0'
     implementation "com.google.firebase:firebase-iid:21.1.0"
-    implementation 'com.pusher:push-notifications-android:1.7.0-alpha'
+    implementation 'com.pusher:push-notifications-android:1.7.0-alpha.1'
 }
 
 // Add this line to the end of the file

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-messaging:22.0.0'
     implementation "com.google.firebase:firebase-iid:21.1.0"
+    implementation 'com.pusher:push-notifications-android:1.6.2'
 }
 
 // Add this line to the end of the file

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-core:16.0.9'
     implementation 'com.google.firebase:firebase-messaging:18.0.0'
-    implementation 'com.pusher:push-notifications-android:1.6.2'
+    implementation 'com.pusher:push-notifications-android:1.7.0-alpha'
 }
 
 // Add this line to the end of the file
@@ -49,7 +49,7 @@ dependencies {
     // Add these lines
     implementation 'com.google.firebase:firebase-messaging:22.0.0'
     implementation "com.google.firebase:firebase-iid:21.1.0"
-    implementation 'com.pusher:push-notifications-android:1.6.2'
+    implementation 'com.pusher:push-notifications-android:1.7.0-alpha'
 }
 
 // Add this line to the end of the file

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.versions = [
-        kotlin: '1.3.10',
+        kotlin: '1.4.32',
 
         androidPlugin: '3.0.0',
         androidTools: '27.0.2',

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,5 @@ org.gradle.jvmargs=-Xmx1536m
 
 # Necessary to work with the latest gradle:
 org.gradle.configureondemand=false
+android.useAndroidX=true
+android.enableJetifier=true

--- a/pushnotifications-integration-tests/build.gradle
+++ b/pushnotifications-integration-tests/build.gradle
@@ -12,7 +12,7 @@ android {
         versionCode 1
         versionName "1.0"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
     }
 
@@ -28,16 +28,16 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 

--- a/pushnotifications-integration-tests/build.gradle
+++ b/pushnotifications-integration-tests/build.gradle
@@ -3,17 +3,22 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.example.pushnotificationsintegrationtests"
         minSdkVersion 26
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     buildTypes {
@@ -26,6 +31,8 @@ android {
 
 
 dependencies {
+    implementation platform('com.google.firebase:firebase-bom:28.0.1')
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
     implementation 'androidx.appcompat:appcompat:1.0.0'
@@ -46,9 +53,10 @@ dependencies {
 
     androidTestImplementation 'org.nanohttpd:nanohttpd:2.2.0'
 
-    implementation "com.google.android.gms:play-services-gcm:15.0.1"
-    implementation "com.google.firebase:firebase-core:16.0.1"
-    implementation "com.google.firebase:firebase-messaging:17.1.0"
+//    implementation "com.google.android.gms:play-services-gcm:15.0.1"
+//    implementation "com.google.firebase:firebase-core:16.0.1"
+    implementation "com.google.firebase:firebase-messaging"
+    implementation "com.google.firebase:firebase-iid"
 
     androidTestImplementation 'org.awaitility:awaitility:3.1.5'
     androidTestImplementation 'org.awaitility:awaitility-kotlin:3.1.5'

--- a/pushnotifications-integration-tests/build.gradle
+++ b/pushnotifications-integration-tests/build.gradle
@@ -31,21 +31,18 @@ android {
 
 
 dependencies {
-    implementation platform('com.google.firebase:firebase-bom:28.0.1')
-
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     implementation project(':pushnotifications')
@@ -53,10 +50,8 @@ dependencies {
 
     androidTestImplementation 'org.nanohttpd:nanohttpd:2.2.0'
 
-//    implementation "com.google.android.gms:play-services-gcm:15.0.1"
-//    implementation "com.google.firebase:firebase-core:16.0.1"
-    implementation "com.google.firebase:firebase-messaging"
-    implementation "com.google.firebase:firebase-iid"
+    implementation "com.google.firebase:firebase-messaging:22.0.0"
+    implementation "com.google.firebase:firebase-iid:21.1.0"
 
     androidTestImplementation 'org.awaitility:awaitility:3.1.5'
     androidTestImplementation 'org.awaitility:awaitility-kotlin:3.1.5'

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ClearAllStateTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ClearAllStateTest.kt
@@ -35,11 +35,11 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class ClearAllStateTest {
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e81"
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -56,7 +56,7 @@ class ClearAllStateTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ClearAllStateTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/ClearAllStateTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.fcm.MessagingService

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
@@ -31,12 +31,12 @@ const val DEVICE_REGISTRATION_WAIT_SECS: Long = 15 // We need to wait for FCM to
  */
 @RunWith(AndroidJUnit4::class)
 class DeviceRegistrationTest {
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e83"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -53,7 +53,7 @@ class DeviceRegistrationTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())
@@ -283,7 +283,7 @@ class DeviceRegistrationTest {
 
     // We want to run these callbacks from the UI thread as it's more likely to be useful
     // for the customers. Although, we are not going to make any promises at this point
-    val mainThread = InstrumentationRegistry.getTargetContext().mainLooper.thread
+    val mainThread = InstrumentationRegistry.getInstrumentation().targetContext.mainLooper.thread
     assertThat(lastSetOnSubscriptionsChangedListenerCalledThread, `is`(equalTo(mainThread)))
   }
 }

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.iid.FirebaseInstanceId
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.SubscriptionsChangedListener

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultiInstanceSupportTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultiInstanceSupportTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.BeamsCallback
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.PusherCallbackError

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultiInstanceSupportTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultiInstanceSupportTest.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class MultiInstanceSupportTest {
-  private val context = InstrumentationRegistry.getTargetContext()
+  private val context = InstrumentationRegistry.getInstrumentation().targetContext
   private val instanceId1 = "00000000-1241-08e9-b379-377c32cd1e80"
   private val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e82"
   private val errolClient1 = ErrolAPI(instanceId1, "http://localhost:8080")
@@ -46,7 +46,7 @@ class MultiInstanceSupportTest {
 
 
   fun getStoredDeviceId(instanceId: String): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -65,7 +65,7 @@ class MultiInstanceSupportTest {
   @After
   fun wipeLocalState() {
     fun wipe(instanceId: String) {
-      val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+      val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
       await.atMost(1, TimeUnit.SECONDS) until {
         assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultipleClassInstancesTests.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultipleClassInstancesTests.kt
@@ -1,8 +1,8 @@
 package com.example.pushnotificationsintegrationtests
 
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.fcm.MessagingService

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultipleClassInstancesTests.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/MultipleClassInstancesTests.kt
@@ -33,12 +33,12 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class MultipleClassInstancesTests {
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e82"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -56,7 +56,7 @@ class MultipleClassInstancesTests {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/SetUserIdTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/SetUserIdTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.*
 import com.pusher.pushnotifications.auth.TokenProvider
 import com.pusher.pushnotifications.fcm.MessagingService

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/SetUserIdTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/SetUserIdTest.kt
@@ -31,13 +31,13 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class SetUserIdTest {
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e84"
   val userId = "alice"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -56,7 +56,7 @@ class SetUserIdTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StartTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StartTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotifications
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.fcm.MessagingService

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StartTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StartTest.kt
@@ -32,13 +32,13 @@ import kotlin.test.asserter
  */
 @RunWith(AndroidJUnit4::class)
 class StartTest {
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e80"
   val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e81"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -55,7 +55,7 @@ class StartTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.fcm.MessagingService
 import com.pusher.pushnotifications.internal.InstanceDeviceStateStore

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/StopTest.kt
@@ -29,12 +29,12 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class StopTest {
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId = "00000000-1241-08e9-b379-377c32cd1e80"
   val errolClient = ErrolAPI(instanceId, "http://localhost:8080")
 
   fun getStoredDeviceId(): String? {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     return deviceStateStore.deviceId
   }
 
@@ -51,7 +51,7 @@ class StopTest {
   @Before
   @After
   fun wipeLocalState() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
 
     await.atMost(1, TimeUnit.SECONDS) until {
       assertTrue(deviceStateStore.clear())

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/DeviceStateStoreTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/DeviceStateStoreTest.kt
@@ -1,8 +1,8 @@
 package com.example.pushnotificationsintegrationtests.internal
 
 import android.content.Context
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.internal.DeviceStateStore
 import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import org.awaitility.kotlin.await

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/DeviceStateStoreTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/DeviceStateStoreTest.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class DeviceStateStoreTest {
-  val context: Context = InstrumentationRegistry.getTargetContext()
+  val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId1 = "00000000-1241-08e9-b379-377c32cd1e80"
   val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e81"
 

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/InstanceDeviceStateStoreTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/InstanceDeviceStateStoreTest.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
  */
 @RunWith(AndroidJUnit4::class)
 class InstanceDeviceStateStoreTest {
-  val context = InstrumentationRegistry.getTargetContext()
+  val context = InstrumentationRegistry.getInstrumentation().targetContext
   val instanceId1 = "00000000-1241-08e9-b379-377c32cd1e80"
   val instanceId2 = "00000000-1241-08e9-b379-377c32cd1e81"
 

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/InstanceDeviceStateStoreTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/internal/InstanceDeviceStateStoreTest.kt
@@ -1,7 +1,7 @@
 package com.example.pushnotificationsintegrationtests.internal
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until

--- a/pushnotifications-integration-tests/src/main/java/com/example/pushnotificationsintegrationtests/MainActivity.kt
+++ b/pushnotifications-integration-tests/src/main/java/com/example/pushnotificationsintegrationtests/MainActivity.kt
@@ -1,6 +1,6 @@
 package com.example.pushnotificationsintegrationtests
 
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 
 class MainActivity : AppCompatActivity() {

--- a/pushnotifications-integration-tests/src/main/res/layout/activity_main.xml
+++ b/pushnotifications-integration-tests/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -15,4 +15,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
-        versionName "1.7.0-alpha.1"
+        versionName "1.7.0"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
-        versionName "1.7-alpha"
+        versionName "1.7.0-alpha"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -48,6 +48,9 @@ dependencies {
     compileOnly "com.google.firebase:firebase-iid:21.1.0"
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
+    implementation("androidx.work:work-runtime-ktx:2.5.0")
+    implementation 'androidx.concurrent:concurrent-futures:1.1.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
 
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     implementation 'androidx.annotation:annotation:1.2.0'

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -11,7 +11,7 @@ android {
         versionCode 1
         versionName "1.6.2"
 
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     buildTypes {
@@ -40,18 +40,18 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:2.13.0"
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.0'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 
     compileOnly "com.google.android.gms:play-services-gcm:16.1.0"
-    compileOnly "com.google.firebase:firebase-core:16.0.9"
-    compileOnly "com.google.firebase:firebase-messaging:18.0.0"
+    compileOnly "com.google.firebase:firebase-messaging:22.0.0"
+    compileOnly "com.google.firebase:firebase-iid:21.1.0"
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
 
-    implementation 'android.arch.lifecycle:extensions:1.1.1'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 
     lintChecks project(':pushnotifications-lint')
 }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
-        versionName "1.6.2"
+        versionName "1.7-alpha"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -32,8 +32,6 @@ android {
 }
 
 dependencies {
-    implementation platform('com.google.firebase:firebase-bom:28.0.1')
-
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
@@ -51,8 +49,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 
-    compileOnly "com.google.firebase:firebase-messaging"
-    compileOnly "com.google.firebase:firebase-iid"
+    compileOnly "com.google.firebase:firebase-messaging:22.0.0"
+    compileOnly "com.google.firebase:firebase-iid:21.1.0"
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
 

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -24,9 +24,16 @@ android {
     defaultConfig {
         consumerProguardFiles 'proguard-rules.pro'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
+    implementation platform('com.google.firebase:firebase-bom:28.0.1')
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
@@ -44,9 +51,10 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 
-    compileOnly "com.google.android.gms:play-services-gcm:16.1.0"
-    compileOnly "com.google.firebase:firebase-messaging:22.0.0"
-    compileOnly "com.google.firebase:firebase-iid:21.1.0"
+//    compileOnly "com.google.android.gms:play-services-gcm:16.1.0"
+//    compileOnly "com.google.firebase:firebase-core:16.0.9"
+    compileOnly "com.google.firebase:firebase-messaging"
+    implementation "com.google.firebase:firebase-iid"
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
 

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 28
         versionCode 1
-        versionName "1.7.0-alpha"
+        versionName "1.7.0-alpha.1"
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -42,11 +42,6 @@ dependencies {
     implementation "dev.zacsweers.moshisealed:moshi-sealed-reflect:0.1.0"
     implementation "dev.zacsweers.moshisealed:moshi-sealed-annotations:0.1.0"
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation "org.mockito:mockito-core:2.13.0"
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
-
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 
     compileOnly "com.google.firebase:firebase-messaging:22.0.0"
@@ -58,6 +53,17 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.2.0'
 
     lintChecks project(':pushnotifications-lint')
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'androidx.test.ext:truth:1.3.0'
+    testImplementation "org.mockito:mockito-core:2.13.0"
+
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }
 
 repositories {

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     compileOnly "com.google.firebase:firebase-messaging:22.0.0"
     compileOnly "com.google.firebase:firebase-iid:21.1.0"
 
-    implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
     implementation("androidx.work:work-runtime-ktx:2.5.0")
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -47,19 +47,17 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "org.mockito:mockito-core:2.13.0"
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
 
-//    compileOnly "com.google.android.gms:play-services-gcm:16.1.0"
-//    compileOnly "com.google.firebase:firebase-core:16.0.9"
     compileOnly "com.google.firebase:firebase-messaging"
-    implementation "com.google.firebase:firebase-iid"
+    compileOnly "com.google.firebase:firebase-iid"
 
     implementation 'com.firebase:firebase-jobdispatcher:0.8.5'
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.annotation:annotation:1.2.0'
 
     lintChecks project(':pushnotifications-lint')
 }

--- a/pushnotifications/gradle.properties
+++ b/pushnotifications/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7.0-alpha.1
+VERSION_NAME=1.7.0
 VERSION_CODE=1
 GROUP=com.pusher
 

--- a/pushnotifications/gradle.properties
+++ b/pushnotifications/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.6.2
+VERSION_NAME=1.7-alpha
 VERSION_CODE=1
 GROUP=com.pusher
 

--- a/pushnotifications/gradle.properties
+++ b/pushnotifications/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7.0-alpha
+VERSION_NAME=1.7.0-alpha.1
 VERSION_CODE=1
 GROUP=com.pusher
 

--- a/pushnotifications/gradle.properties
+++ b/pushnotifications/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.7-alpha
+VERSION_NAME=1.7.0-alpha
 VERSION_CODE=1
 GROUP=com.pusher
 

--- a/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
+++ b/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
@@ -1,7 +1,7 @@
 package com.pusher.pushnotifications
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.pusher.pushnotifications.api.DeviceMetadata
 import com.pusher.pushnotifications.api.PushNotificationsAPI
 import com.pusher.pushnotifications.api.PushNotificationsAPIUnprocessableEntity
@@ -33,7 +33,7 @@ class ServerSyncProcessHandlerTest {
   @Before
   @After
   fun cleanup() {
-    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(androidx.test.platform.app.InstrumentationRegistry.getTargetContext(), instanceId)
     Assert.assertTrue(deviceStateStore.clear())
     Assert.assertNull(deviceStateStore.deviceId)
     Assert.assertThat(deviceStateStore.interests.size, `is`(equalTo(0)))
@@ -41,7 +41,7 @@ class ServerSyncProcessHandlerTest {
 
   private val mockServer = MockWebServer().apply { start() }
   private val api = PushNotificationsAPI(instanceId, mockServer.url("/").toString())
-  private val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getTargetContext(), instanceId)
+  private val deviceStateStore = InstanceDeviceStateStore(androidx.test.platform.app.InstrumentationRegistry.getTargetContext(), instanceId)
   val moshi = Moshi.Builder()
           .add(MoshiSealedJsonAdapterFactory())
           .add(KotlinJsonAdapterFactory()).build()
@@ -52,7 +52,7 @@ class ServerSyncProcessHandlerTest {
     tempFile.delete() // QueueFile expects a handle to a non-existent file on first run.
     TapeJobQueue<ServerSyncJob>(tempFile, converter)
   }()
-  private val looper = InstrumentationRegistry.getContext().mainLooper
+  private val looper = androidx.test.platform.app.InstrumentationRegistry.getContext().mainLooper
   private var lastHandleServerSyncEvent: ServerSyncEvent? = null
   private var tokenProvider: TokenProvider? = null
   private val handler = ServerSyncProcessHandler(

--- a/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
+++ b/pushnotifications/src/androidTest/java/com/pusher/pushnotifications/ServerSyncProcessHandlerTest.kt
@@ -33,7 +33,7 @@ class ServerSyncProcessHandlerTest {
   @Before
   @After
   fun cleanup() {
-    val deviceStateStore = InstanceDeviceStateStore(androidx.test.platform.app.InstrumentationRegistry.getTargetContext(), instanceId)
+    val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
     Assert.assertTrue(deviceStateStore.clear())
     Assert.assertNull(deviceStateStore.deviceId)
     Assert.assertThat(deviceStateStore.interests.size, `is`(equalTo(0)))
@@ -41,7 +41,7 @@ class ServerSyncProcessHandlerTest {
 
   private val mockServer = MockWebServer().apply { start() }
   private val api = PushNotificationsAPI(instanceId, mockServer.url("/").toString())
-  private val deviceStateStore = InstanceDeviceStateStore(androidx.test.platform.app.InstrumentationRegistry.getTargetContext(), instanceId)
+  private val deviceStateStore = InstanceDeviceStateStore(InstrumentationRegistry.getInstrumentation().targetContext, instanceId)
   val moshi = Moshi.Builder()
           .add(MoshiSealedJsonAdapterFactory())
           .add(KotlinJsonAdapterFactory()).build()
@@ -52,7 +52,7 @@ class ServerSyncProcessHandlerTest {
     tempFile.delete() // QueueFile expects a handle to a non-existent file on first run.
     TapeJobQueue<ServerSyncJob>(tempFile, converter)
   }()
-  private val looper = androidx.test.platform.app.InstrumentationRegistry.getContext().mainLooper
+  private val looper = InstrumentationRegistry.getInstrumentation().targetContext.mainLooper
   private var lastHandleServerSyncEvent: ServerSyncEvent? = null
   private var tokenProvider: TokenProvider? = null
   private val handler = ServerSyncProcessHandler(

--- a/pushnotifications/src/main/AndroidManifest.xml
+++ b/pushnotifications/src/main/AndroidManifest.xml
@@ -15,14 +15,6 @@
                 <category android:name="${applicationId}" />
             </intent-filter>
         </receiver>
-        <service
-            android:name="com.pusher.pushnotifications.reporting.ReportingJobService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.firebase.jobdispatcher.ACTION_EXECUTE"/>
-            </intent-filter>
-        </service>
 
         <service
             android:name="com.pusher.pushnotifications.fcm.EmptyMessagingService">

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -361,7 +361,7 @@ class PushNotificationsInstance @JvmOverloads constructor(
    * @param callback callback used to indicate whether the user association process has succeeded
    */
   @JvmOverloads
-  fun setUserId(userId: String, tokenProvider: TokenProvider, callback: BeamsCallback<Void, PusherCallbackError> = NoopBeamsCallback()) {
+  fun setUserId(userId: String, tokenProvider: TokenProvider?, callback: BeamsCallback<Void, PusherCallbackError> = NoopBeamsCallback()) {
     if (tokenProvider == null) { // this can happen when using Java
       throw IllegalStateException("Token provider can't be null")
     }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/api/PushNotificationsAPI.kt
@@ -104,6 +104,11 @@ class PushNotificationsAPI(private val instanceId: String, overrideHostURL: Stri
   // Handles the JsonSyntaxException properly
   private fun safeExtractJsonError(possiblyJson: String): NOKResponse {
     return try {
+      // This if check is added to make it work as old Kotlin version.
+      // Need to be revisited in future
+      if (possiblyJson.trim() == ""){
+        throw IllegalStateException("Empty json string")
+      }
       gson.fromJson(possiblyJson, NOKResponse::class.java)
     } catch (jsonException: JsonSyntaxException) {
       log.w("Failed to parse json `$possiblyJson`", jsonException)

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/MessagingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/MessagingService.kt
@@ -93,10 +93,10 @@ abstract class MessagingService: Service() {
           { token: String -> this.onNewToken(token) }
       )
 
-  override fun onBind(i: Intent?): IBinder = underlyingService.onBind(i)
+  override fun onBind(i: Intent?): IBinder = underlyingService.onBind(i!!)
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
-      underlyingService.onStartCommand(intent, flags, startId)
+      underlyingService.onStartCommand(intent!!, flags, startId)
 
   abstract fun onMessageReceived(remoteMessage: RemoteMessage)
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ApplicationLifecycle.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/internal/ApplicationLifecycle.kt
@@ -3,7 +3,7 @@ package com.pusher.pushnotifications.internal
 import java.lang.ref.WeakReference
 import android.app.Activity
 import android.app.Application
-import android.arch.lifecycle.*
+import androidx.lifecycle.*
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.database.Cursor

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -56,17 +56,6 @@ class FCMMessageReceiver : androidx.legacy.content.WakefulBroadcastReceiver() {
                 hasData = pusherData.hasData
         )
 
-//        val dispatcher = FirebaseJobDispatcher(GooglePlayDriver(context))
-//        val job = dispatcher.newJobBuilder()
-//                .setService(ReportingJobService::class.java)
-//                .setTag("pusher.delivered.publishId=${pusherData.publishId}")
-//                .setConstraints(Constraint.ON_ANY_NETWORK)
-//                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
-//                .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
-//                .setExtras(ReportingJobService.toBundle(reportEvent))
-//                .build()
-
-//        dispatcher.mustSchedule(job)
         val reportWorker = OneTimeWorkRequest.Builder(ReportingWorker::class.java)
                 .setConstraints(Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -55,16 +55,17 @@ class FCMMessageReceiver : androidx.legacy.content.WakefulBroadcastReceiver() {
                 hasData = pusherData.hasData
         )
 
-        val dispatcher = FirebaseJobDispatcher(GooglePlayDriver(context))
-        val job = dispatcher.newJobBuilder()
-                .setService(ReportingJobService::class.java)
-                .setTag("pusher.delivered.publishId=${pusherData.publishId}")
-                .setConstraints(Constraint.ON_ANY_NETWORK)
-                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
-                .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
-                .setExtras(ReportingJobService.toBundle(reportEvent))
-                .build()
+//        val dispatcher = FirebaseJobDispatcher(GooglePlayDriver(context))
+//        val job = dispatcher.newJobBuilder()
+//                .setService(ReportingJobService::class.java)
+//                .setTag("pusher.delivered.publishId=${pusherData.publishId}")
+//                .setConstraints(Constraint.ON_ANY_NETWORK)
+//                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
+//                .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
+//                .setExtras(ReportingJobService.toBundle(reportEvent))
+//                .build()
 
+//        dispatcher.mustSchedule(job)
         val reportWorker = OneTimeWorkRequest.Builder(ReportingWorker::class.java)
                 .setConstraints(Constraints.Builder()
                         .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -77,7 +78,7 @@ class FCMMessageReceiver : androidx.legacy.content.WakefulBroadcastReceiver() {
                 ExistingWorkPolicy.KEEP,
                 reportWorker)
 
-        dispatcher.mustSchedule(job)
+
       } catch (_: JsonSyntaxException) {
         // TODO: Add client-side reporting
       }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -3,6 +3,7 @@ package com.pusher.pushnotifications.reporting
 import android.content.Context
 import android.content.Intent
 import androidx.legacy.content.WakefulBroadcastReceiver
+import androidx.work.*
 //import androidx.legacy.content.WakefulBroadcastReceiver
 import com.firebase.jobdispatcher.*
 import com.google.gson.Gson
@@ -44,25 +45,37 @@ class FCMMessageReceiver : androidx.legacy.content.WakefulBroadcastReceiver() {
         }
 
         val reportEvent = DeliveryEvent(
-          instanceId = pusherData.instanceId,
-          publishId = pusherData.publishId,
-          deviceId = deviceId,
-          userId = deviceStateStore.userId,
-          timestampSecs = Math.round(System.currentTimeMillis() / 1000.0),
-          appInBackground = AppActivityLifecycleCallbacks.appInBackground(),
-          hasDisplayableContent = pusherData.hasDisplayableContent,
-          hasData = pusherData.hasData
+                instanceId = pusherData.instanceId,
+                publishId = pusherData.publishId,
+                deviceId = deviceId,
+                userId = deviceStateStore.userId,
+                timestampSecs = Math.round(System.currentTimeMillis() / 1000.0),
+                appInBackground = AppActivityLifecycleCallbacks.appInBackground(),
+                hasDisplayableContent = pusherData.hasDisplayableContent,
+                hasData = pusherData.hasData
         )
 
         val dispatcher = FirebaseJobDispatcher(GooglePlayDriver(context))
         val job = dispatcher.newJobBuilder()
-          .setService(ReportingJobService::class.java)
-          .setTag("pusher.delivered.publishId=${pusherData.publishId}")
-          .setConstraints(Constraint.ON_ANY_NETWORK)
-          .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
-          .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
-          .setExtras(ReportingJobService.toBundle(reportEvent))
-          .build()
+                .setService(ReportingJobService::class.java)
+                .setTag("pusher.delivered.publishId=${pusherData.publishId}")
+                .setConstraints(Constraint.ON_ANY_NETWORK)
+                .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
+                .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
+                .setExtras(ReportingJobService.toBundle(reportEvent))
+                .build()
+
+        val reportWorker = OneTimeWorkRequest.Builder(ReportingWorker::class.java)
+                .setConstraints(Constraints.Builder()
+                        .setRequiredNetworkType(NetworkType.CONNECTED)
+                        .build())
+                .setInputData(ReportingWorker.toInputData(reportEvent))
+                .build()
+
+        val workManagerInstance = WorkManager.getInstance(context)
+        workManagerInstance.enqueueUniqueWork("pusher.delivered.publishId=${pusherData.publishId}",
+                ExistingWorkPolicy.KEEP,
+                reportWorker)
 
         dispatcher.mustSchedule(job)
       } catch (_: JsonSyntaxException) {

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/FCMMessageReceiver.kt
@@ -2,7 +2,8 @@ package com.pusher.pushnotifications.reporting
 
 import android.content.Context
 import android.content.Intent
-import android.support.v4.content.WakefulBroadcastReceiver
+import androidx.legacy.content.WakefulBroadcastReceiver
+//import androidx.legacy.content.WakefulBroadcastReceiver
 import com.firebase.jobdispatcher.*
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
@@ -14,7 +15,7 @@ import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.DeliveryEvent
 
-class FCMMessageReceiver : WakefulBroadcastReceiver() {
+class FCMMessageReceiver : androidx.legacy.content.WakefulBroadcastReceiver() {
   private val gson = Gson()
   private val log = Logger.get(this::class)
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/OpenNotificationActivity.kt
@@ -3,10 +3,9 @@ package com.pusher.pushnotifications.reporting
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import com.firebase.jobdispatcher.*
+import androidx.work.*
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import com.pusher.pushnotifications.internal.DeviceStateStore
 import com.pusher.pushnotifications.internal.InstanceDeviceStateStore
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.OpenEvent
@@ -69,17 +68,17 @@ class OpenNotificationActivity: Activity() {
                    timestampSecs = System.currentTimeMillis() / 1000
                 )
 
-                val dispatcher = FirebaseJobDispatcher(GooglePlayDriver(applicationContext))
-                val job = dispatcher.newJobBuilder()
-                        .setService(ReportingJobService::class.java)
-                        .setTag("pusher.open.publishId=${pusherData.publishId}")
-                        .setConstraints(Constraint.ON_ANY_NETWORK)
-                        .setRetryStrategy(RetryStrategy.DEFAULT_EXPONENTIAL)
-                        .setLifetime(Lifetime.UNTIL_NEXT_BOOT)
-                        .setExtras(ReportingJobService.toBundle(reportEvent))
+                val reportWorker = OneTimeWorkRequest.Builder(ReportingWorker::class.java)
+                        .setConstraints(Constraints.Builder()
+                                .setRequiredNetworkType(NetworkType.CONNECTED)
+                                .build())
+                        .setInputData(ReportingWorker.toInputData(reportEvent))
                         .build()
 
-                dispatcher.mustSchedule(job)
+                val workManagerInstance = WorkManager.getInstance(applicationContext)
+                workManagerInstance.enqueueUniqueWork("pusher.open.publishId=${pusherData.publishId}",
+                        ExistingWorkPolicy.KEEP,
+                        reportWorker)
 
                 startIntent(intent.extras, pusherData.clickAction)
             } catch (_: JsonSyntaxException) {

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -1,19 +1,27 @@
 package com.pusher.pushnotifications.reporting
 
+import android.content.Context
 import android.os.Bundle
+import android.util.Log
+import androidx.concurrent.futures.CallbackToFutureAdapter
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
 import com.firebase.jobdispatcher.JobParameters
 import com.firebase.jobdispatcher.JobService
+import com.google.common.util.concurrent.ListenableFuture
 import com.google.gson.annotations.SerializedName
 import com.pusher.pushnotifications.api.OperationCallbackNoArgs
 import com.pusher.pushnotifications.logging.Logger
 import com.pusher.pushnotifications.reporting.api.*
+import kotlinx.coroutines.CoroutineScope
 
 data class PusherMetadata(
-  val instanceId: String,
-  val publishId: String,
-  val clickAction: String?,
-  @SerializedName("hasDisplayableContent") private val _hasDisplayableContent: Boolean?,
-  @SerializedName("hasData") private val _hasData: Boolean?
+        val instanceId: String,
+        val publishId: String,
+        val clickAction: String?,
+        @SerializedName("hasDisplayableContent") private val _hasDisplayableContent: Boolean?,
+        @SerializedName("hasData") private val _hasData: Boolean?
 ) {
   val hasDisplayableContent: Boolean
     get() = _hasDisplayableContent ?: false
@@ -22,7 +30,166 @@ data class PusherMetadata(
     get() = _hasData ?: false
 }
 
-class ReportingJobService: JobService() {
+class ReportingWorker(appContext: Context, params: WorkerParameters) : ListenableWorker(appContext, params) {
+  companion object {
+    private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
+    private const val BUNDLE_INSTANCE_ID_KEY = "InstanceId"
+    private const val BUNDLE_DEVICE_ID_KEY = "DeviceId"
+    private const val BUNDLE_USER_ID_KEY = "UserId"
+    private const val BUNDLE_PUBLISH_ID_KEY = "PublishId"
+    private const val BUNDLE_TIMESTAMP_KEY = "Timestamp"
+    private const val BUNDLE_APP_IN_BACKGROUND_KEY = "AppInBackground"
+    private const val BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY = "HasDisplayableContent"
+    private const val BUNDLE_HAS_DATA_KEY = "HasData"
+
+    fun toBundle(reportEvent: ReportEvent): Bundle {
+      val b = Bundle()
+      when (reportEvent) {
+        is DeliveryEvent -> {
+          b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
+          b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
+          b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
+          b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
+          b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
+          b.putBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, reportEvent.appInBackground!!)
+          b.putBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY, reportEvent.hasDisplayableContent!!)
+          b.putBoolean(BUNDLE_HAS_DATA_KEY, reportEvent.hasData!!)
+        }
+
+        is OpenEvent -> {
+          b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
+          b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
+          b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
+          b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
+          b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
+        }
+      }
+
+      return b
+    }
+
+    private class MissingInstanceIdException : RuntimeException()
+    private class MissingEventTypeException : java.lang.RuntimeException()
+
+    @Throws(MissingInstanceIdException::class, MissingEventTypeException::class)
+    private fun fromData(data: Data): ReportEvent {
+      val instanceId: String? = data.getString(BUNDLE_INSTANCE_ID_KEY)
+      @Suppress("FoldInitializerAndIfToElvis")
+      if (instanceId == null) {
+        // It's possible that we are processing a bundle that was created with an old SDK
+        // version that didn't had this key. Our migration strategy is to drop the reporting
+        // as it's (a) a rare one-time transition and (b) it's a best effort feature.
+        // Throwing a specific exception (to not compromise the code design -- nullable return
+        // type) which will be caught on calling this private fun.
+        throw MissingInstanceIdException()
+      }
+
+      val event = data.getString(BUNDLE_EVENT_TYPE_KEY)?.let { ReportEventType.valueOf(it) }
+              ?: throw MissingEventTypeException()
+
+      when (event) {
+        ReportEventType.Delivery -> {
+          return DeliveryEvent(
+                  instanceId = instanceId,
+                  deviceId = data.getString(BUNDLE_DEVICE_ID_KEY) ?: "",
+                  userId = data.getString(BUNDLE_USER_ID_KEY),
+                  publishId = data.getString(BUNDLE_PUBLISH_ID_KEY) ?: "",
+                  timestampSecs = data.getLong(BUNDLE_TIMESTAMP_KEY, 0L),
+                  appInBackground = data.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, false),
+                  hasDisplayableContent = data.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY, false),
+                  hasData = data.getBoolean(BUNDLE_HAS_DATA_KEY, false)
+          )
+        }
+        ReportEventType.Open -> {
+          return OpenEvent(
+                  instanceId = instanceId,
+                  deviceId = data.getString(BUNDLE_DEVICE_ID_KEY) ?: "",
+                  userId = data.getString(BUNDLE_USER_ID_KEY),
+                  publishId = data.getString(BUNDLE_PUBLISH_ID_KEY) ?: "",
+                  timestampSecs = data.getLong(BUNDLE_TIMESTAMP_KEY, 0L)
+          )
+        }
+      }
+    }
+
+    fun toInputData(reportEvent: ReportEvent): Data {
+      val d = Data.Builder()
+      when (reportEvent) {
+        is DeliveryEvent -> {
+          d.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
+                  .putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
+                  .putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+                  .putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
+                  .putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
+                  .putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
+                  .putBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, reportEvent.appInBackground!!)
+                  .putBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY, reportEvent.hasDisplayableContent!!)
+                  .putBoolean(BUNDLE_HAS_DATA_KEY, reportEvent.hasData!!)
+        }
+
+        is OpenEvent -> {
+          d.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
+                  .putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
+                  .putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
+                  .putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
+                  .putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
+                  .putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
+        }
+      }
+      return d.build()
+    }
+  }
+
+  private val log = Logger.get(this::class)
+  override fun startWork(): ListenableFuture<Result> {
+    return CallbackToFutureAdapter.getFuture { completer ->
+      try {
+        Log.e("WORKER", String.format("*********INPUT DATA: %s", inputData.toString()))
+        val reportEvent = fromData(inputData)
+        Log.e("WORKER", String.format("*********Event DATA: %s", reportEvent.toString()))
+        reportEvent.deviceId
+
+        ReportingAPI(reportEvent.instanceId).submit(
+                reportEvent = reportEvent,
+                operationCallback = object : OperationCallbackNoArgs {
+                  override fun onSuccess() {
+                    log.v("Successfully submitted report.")
+                    Log.e("WORKER", "Successfully submitted report.")
+                    completer.set(Result.success(inputData))
+                  }
+
+                  override fun onFailure(t: Throwable) {
+                    log.w("Failed submitted report.", t)
+                    Log.e("WORKER", String.format("Successfully submitted report. %s", t))
+                    if (t !is UnrecoverableRuntimeException) {
+                      completer.set(Result.retry())
+                    } else {
+                      completer.set(Result.failure(inputData))
+                    }
+                  }
+                }
+        )
+      } catch (e: MissingInstanceIdException) {
+        log.w("Missing instance id, can't report.")
+        Log.e("WORKER", "Missing instance id, can't report.")
+        completer.set(Result.failure())
+      } catch (e: MissingEventTypeException) {
+        log.w("Missing event type, can't report.")
+        Log.e("WORKER", "Missing event type, can't report.")
+        completer.set(Result.failure())
+      }
+    }
+
+  }
+
+  override fun onStopped() {
+    super.onStopped()
+  }
+}
+
+class ReportingJobService : JobService() {
   companion object {
     private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
     private const val BUNDLE_INSTANCE_ID_KEY = "InstanceId"

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/ReportingJobService.kt
@@ -2,13 +2,10 @@ package com.pusher.pushnotifications.reporting
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.work.Data
 import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
-import com.firebase.jobdispatcher.JobParameters
-import com.firebase.jobdispatcher.JobService
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.gson.annotations.SerializedName
 import com.pusher.pushnotifications.api.OperationCallbackNoArgs
@@ -140,9 +137,7 @@ class ReportingWorker(appContext: Context, params: WorkerParameters) : Listenabl
   override fun startWork(): ListenableFuture<Result> {
     return CallbackToFutureAdapter.getFuture { completer ->
       try {
-        Log.e("WORKER", String.format("*********INPUT DATA: %s", inputData.toString()))
         val reportEvent = fromData(inputData)
-        Log.e("WORKER", String.format("*********Event DATA: %s", reportEvent.toString()))
         reportEvent.deviceId
 
         ReportingAPI(reportEvent.instanceId).submit(
@@ -150,13 +145,11 @@ class ReportingWorker(appContext: Context, params: WorkerParameters) : Listenabl
                 operationCallback = object : OperationCallbackNoArgs {
                   override fun onSuccess() {
                     log.v("Successfully submitted report.")
-                    Log.e("WORKER", "Successfully submitted report.")
                     completer.set(Result.success(inputData))
                   }
 
                   override fun onFailure(t: Throwable) {
                     log.w("Failed submitted report.", t)
-                    Log.e("WORKER", String.format("Successfully submitted report. %s", t))
                     if (t !is UnrecoverableRuntimeException) {
                       completer.set(Result.retry())
                     } else {
@@ -167,142 +160,13 @@ class ReportingWorker(appContext: Context, params: WorkerParameters) : Listenabl
         )
       } catch (e: MissingInstanceIdException) {
         log.w("Missing instance id, can't report.")
-        Log.e("WORKER", "Missing instance id, can't report.")
         completer.set(Result.failure())
       } catch (e: MissingEventTypeException) {
         log.w("Missing event type, can't report.")
-        Log.e("WORKER", "Missing event type, can't report.")
         completer.set(Result.failure())
       }
     }
 
   }
 
-}
-
-class ReportingJobService : JobService() {
-  companion object {
-    private const val BUNDLE_EVENT_TYPE_KEY = "ReportEventType"
-    private const val BUNDLE_INSTANCE_ID_KEY = "InstanceId"
-    private const val BUNDLE_DEVICE_ID_KEY = "DeviceId"
-    private const val BUNDLE_USER_ID_KEY = "UserId"
-    private const val BUNDLE_PUBLISH_ID_KEY = "PublishId"
-    private const val BUNDLE_TIMESTAMP_KEY = "Timestamp"
-    private const val BUNDLE_APP_IN_BACKGROUND_KEY = "AppInBackground"
-    private const val BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY = "HasDisplayableContent"
-    private const val BUNDLE_HAS_DATA_KEY = "HasData"
-
-    fun toBundle(reportEvent: ReportEvent): Bundle {
-      val b = Bundle()
-      when (reportEvent) {
-        is DeliveryEvent -> {
-          b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
-          b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
-          b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
-          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
-          b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
-          b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
-          b.putBoolean(BUNDLE_APP_IN_BACKGROUND_KEY, reportEvent.appInBackground!!)
-          b.putBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY, reportEvent.hasDisplayableContent!!)
-          b.putBoolean(BUNDLE_HAS_DATA_KEY, reportEvent.hasData!!)
-        }
-
-        is OpenEvent -> {
-          b.putString(BUNDLE_EVENT_TYPE_KEY, reportEvent.event.toString())
-          b.putString(BUNDLE_INSTANCE_ID_KEY, reportEvent.instanceId)
-          b.putString(BUNDLE_DEVICE_ID_KEY, reportEvent.deviceId)
-          b.putString(BUNDLE_USER_ID_KEY, reportEvent.userId)
-          b.putString(BUNDLE_PUBLISH_ID_KEY, reportEvent.publishId)
-          b.putLong(BUNDLE_TIMESTAMP_KEY, reportEvent.timestampSecs)
-        }
-      }
-
-      return b
-    }
-
-    private class MissingInstanceIdException : RuntimeException()
-
-    @Throws(MissingInstanceIdException::class)
-    private fun fromBundle(bundle: Bundle): ReportEvent {
-      val instanceId : String? = bundle.getString(BUNDLE_INSTANCE_ID_KEY)
-      @Suppress("FoldInitializerAndIfToElvis")
-      if (instanceId == null) {
-        // It's possible that we are processing a bundle that was created with an old SDK
-        // version that didn't had this key. Our migration strategy is to drop the reporting
-        // as it's (a) a rare one-time transition and (b) it's a best effort feature.
-        // Throwing a specific exception (to not compromise the code design -- nullable return
-        // type) which will be caught on calling this private fun.
-        throw MissingInstanceIdException()
-      }
-
-      val event = ReportEventType.valueOf(bundle.getString(BUNDLE_EVENT_TYPE_KEY))
-      when (event) {
-        ReportEventType.Delivery -> {
-          return DeliveryEvent(
-                  instanceId = instanceId,
-                  deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
-                  userId = bundle.getString(BUNDLE_USER_ID_KEY),
-                  publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
-                  timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY),
-                  appInBackground = bundle.getBoolean(BUNDLE_APP_IN_BACKGROUND_KEY),
-                  hasDisplayableContent = bundle.getBoolean(BUNDLE_HAS_DISPLAYABLE_CONTENT_KEY),
-                  hasData = bundle.getBoolean(BUNDLE_HAS_DATA_KEY)
-          )
-        }
-        ReportEventType.Open -> {
-          return OpenEvent(
-                  instanceId = instanceId,
-                  deviceId = bundle.getString(BUNDLE_DEVICE_ID_KEY),
-                  userId = bundle.getString(BUNDLE_USER_ID_KEY),
-                  publishId = bundle.getString(BUNDLE_PUBLISH_ID_KEY),
-                  timestampSecs = bundle.getLong(BUNDLE_TIMESTAMP_KEY)
-          )
-        }
-      }
-    }
-  }
-
-  private val log = Logger.get(this::class)
-
-  override fun onStartJob(params: JobParameters?): Boolean {
-    params?.let {
-      val extras = it.extras
-
-      if (extras != null) {
-        try {
-          val reportEvent = fromBundle(extras)
-          reportEvent.deviceId
-
-          ReportingAPI(reportEvent.instanceId).submit(
-            reportEvent = reportEvent,
-            operationCallback = object: OperationCallbackNoArgs {
-              override fun onSuccess() {
-                log.v("Successfully submitted report.")
-                jobFinished(params, false)
-              }
-
-              override fun onFailure(t: Throwable) {
-                log.w("Failed submitted report.", t)
-                val shouldRetry = t !is UnrecoverableRuntimeException
-
-                jobFinished(params, shouldRetry)
-              }
-            }
-          )
-        } catch (e : MissingInstanceIdException) {
-          log.w("Missing instance id, can't report.")
-          return false
-        }
-      } else {
-        log.w("Incorrect start of service: extras bundle is missing.")
-        return false
-      }
-    }
-
-    return true // A background job was started
-  }
-
-  override fun onStopJob(params: JobParameters?): Boolean {
-    return true // Answers the question: "Should this job be retried?"
-  }
 }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingAPI.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/reporting/api/ReportingAPI.kt
@@ -1,10 +1,8 @@
 package com.pusher.pushnotifications.reporting.api
 
 import com.google.gson.Gson
-import com.pusher.pushnotifications.api.PusherLibraryHeaderInterceptor
-import com.pusher.pushnotifications.api.OperationCallback
 import com.pusher.pushnotifications.api.OperationCallbackNoArgs
-import com.pusher.pushnotifications.reporting.ReportingJobService
+import com.pusher.pushnotifications.api.PusherLibraryHeaderInterceptor
 import okhttp3.OkHttpClient
 import retrofit2.Call
 import retrofit2.Callback

--- a/sample_kotlin/build.gradle
+++ b/sample_kotlin/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.pusher.pushnotifications.sample"
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
@@ -24,17 +24,22 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 
     implementation project(':pushnotifications')
     lintChecks project(':pushnotifications-lint')

--- a/sample_kotlin/build.gradle
+++ b/sample_kotlin/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         debug {
@@ -29,12 +29,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:support-v4:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 
     implementation project(':pushnotifications')
     lintChecks project(':pushnotifications-lint')

--- a/sample_kotlin/src/androidTest/java/com/pusher/sample/ExampleInstrumentedTest.kt
+++ b/sample_kotlin/src/androidTest/java/com/pusher/sample/ExampleInstrumentedTest.kt
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = androidx.test.platform.app.InstrumentationRegistry.getTargetContext()
+        val appContext = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("com.pusher.push_notifications_android", appContext.packageName)
     }
 }

--- a/sample_kotlin/src/androidTest/java/com/pusher/sample/ExampleInstrumentedTest.kt
+++ b/sample_kotlin/src/androidTest/java/com/pusher/sample/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package com.pusher.sample
 
-import android.support.test.InstrumentationRegistry
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = androidx.test.platform.app.InstrumentationRegistry.getTargetContext()
         assertEquals("com.pusher.push_notifications_android", appContext.packageName)
     }
 }

--- a/sample_kotlin/src/main/java/com/pusher/pushnotifications/sample/MainActivity.kt
+++ b/sample_kotlin/src/main/java/com/pusher/pushnotifications/sample/MainActivity.kt
@@ -1,7 +1,7 @@
 package com.pusher.pushnotifications.sample
 
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
 import com.google.firebase.messaging.RemoteMessage
 import com.pusher.pushnotifications.PushNotificationReceivedListener

--- a/sample_kotlin/src/main/res/layout/activity_main.xml
+++ b/sample_kotlin/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -15,4 +15,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This PR contains changes to 
-  migrate to AndroidX which is the new way for feature parity acroos Android versions. I used Migrate to AndroidX... feature of the Android Studio and resolved few of the issues that cropped up.
- Updating the Firebase dependencies
- Introduce Android WorkManager in place of Firebase JobDispatcher

This should sidestep https://github.com/pusher/push-notifications-android/issues/117 for now until we move to FIrebase Installations and fix https://github.com/pusher/push-notifications-android/issues/112