### PR TITLE
Support Android 12 (build tools 31)

### DIFF
--- a/pushnotifications/src/main/AndroidManifest.xml
+++ b/pushnotifications/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         </receiver>
 
         <service
-            android:name="com.pusher.pushnotifications.fcm.EmptyMessagingService">
+            android:name="com.pusher.pushnotifications.fcm.EmptyMessagingService"
+            android:exported="false">
             <intent-filter android:priority="1">
                 <action android:name="com.google.firebase.MESSAGING_EVENT"/>
             </intent-filter>
@@ -29,7 +30,9 @@
             android:exported="false"
             android:initOrder="99" />
 
-        <activity android:name="com.pusher.pushnotifications.reporting.OpenNotificationActivity">
+        <activity 
+            android:name="com.pusher.pushnotifications.reporting.OpenNotificationActivity"
+            android:exported="false" >
             <intent-filter>
                 <action android:name="com.pusher.pushnotifications.OPEN_TRACKING" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Solves https://github.com/pusher/push-notifications-android/issues/123

If you target Android 12 when building (`targetSdkVersion 31`), you get this error:

```
Manifest merger failed : android:exported needs to be explicitly specified for <activity>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details.
```

You need to set `android:exported` for everything that has an intent in the manifest. 


note: as a workaround I set this in my apps' `AndroidManifest.xml`, but I should not:
```xml
        <!-- Fixes to Pusher to support Android 12 -->
        <service
            android:name="com.pusher.pushnotifications.fcm.EmptyMessagingService"
            android:exported="false"
            tools:node="merge" />
        <activity
            android:name="com.pusher.pushnotifications.reporting.OpenNotificationActivity"
            android:exported="false"
            tools:node="merge" />
```