### PR TITLE
Fix Android 12 crash

### DIFF
--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     compileOnly "com.google.firebase:firebase-messaging:22.0.0"
     compileOnly "com.google.firebase:firebase-iid:21.1.0"
 
-    implementation("androidx.work:work-runtime-ktx:2.5.0")
+    implementation("androidx.work:work-runtime-ktx:2.7.0")
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1'
 


### PR DESCRIPTION
This PR fixes #127

Pusher is using an old version of WorkManager which makes apps crash as soon as they are launched.

Version 2.7.0-alpha02 adds Android 12 compatibility: https://developer.android.com/jetpack/androidx/releases/work#2.7.0-alpha02

This PR upgrades WorkManager to the latest stable version: 2.7.0