### PR TITLE
Fix Start Stop Behavior

### DIFF
--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -4,7 +4,7 @@ apply from: 'maven-push.gradle'
 
 android {
     compileSdkVersion 31
-
+    
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29
@@ -30,7 +30,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -30,7 +30,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 }

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -4,7 +4,7 @@ apply from: 'maven-push.gradle'
 
 android {
     compileSdkVersion 31
-    
+
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 29

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotifications.java
@@ -28,7 +28,6 @@ public class PushNotifications {
     public static PushNotificationsInstance start(Context context, String instanceId) {
         if (instance == null) {
             instance = new PushNotificationsInstance(context, instanceId);
-            instance.start();
         } else if (!instance.getInstanceId().equals(instanceId)) {
             String errorMessage =
                     "PushNotifications.start has been called before with a different instanceId! (before: "
@@ -39,6 +38,7 @@ public class PushNotifications {
             throw new IllegalStateException(errorMessage);
         }
 
+        instance.start();
         return instance;
     }
 

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -166,16 +166,16 @@ class PushNotificationsInstance @JvmOverloads constructor(
     val handleFcmToken = { fcmToken: String ->
       synchronized(deviceStateStore) {
         if (startHasBeenCalledThisSession) {
-        if (deviceStateStore.startJobHasBeenEnqueued) {
-          serverSyncHandler.sendMessage(ServerSyncHandler.refreshToken(fcmToken))
-        } else {
+          if (deviceStateStore.startJobHasBeenEnqueued) {
+            serverSyncHandler.sendMessage(ServerSyncHandler.refreshToken(fcmToken))
+          } else {
             serverSyncHandler.sendMessage(
               ServerSyncHandler.start(
                 fcmToken,
                 oldSDKDeviceStateStore.clientIds()
               )
             )
-          deviceStateStore.startJobHasBeenEnqueued = true
+            deviceStateStore.startJobHasBeenEnqueued = true
           }
         }
       }

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -165,11 +165,18 @@ class PushNotificationsInstance @JvmOverloads constructor(
     startHasBeenCalledThisSession = true
     val handleFcmToken = { fcmToken: String ->
       synchronized(deviceStateStore) {
+        if (startHasBeenCalledThisSession) {
         if (deviceStateStore.startJobHasBeenEnqueued) {
           serverSyncHandler.sendMessage(ServerSyncHandler.refreshToken(fcmToken))
         } else {
-          serverSyncHandler.sendMessage(ServerSyncHandler.start(fcmToken, oldSDKDeviceStateStore.clientIds()))
+            serverSyncHandler.sendMessage(
+              ServerSyncHandler.start(
+                fcmToken,
+                oldSDKDeviceStateStore.clientIds()
+              )
+            )
           deviceStateStore.startJobHasBeenEnqueued = true
+          }
         }
       }
 


### PR DESCRIPTION
Issues:

- Calling stop immediately after calling start doesn’t deregister the device nor stop the device from being registered! The device will be registered and will receive notifications.
- Calling stop immediately after start invalidates the state of the SDK. Therefore, other method calls like setUserID cannot be called afterward.
- Calling stop later, after the registration is already done, will deregister the device.
- Calling start() after calling stop() (immediately or later) does not bring the SDK to a valid state anymore and it does not register the device.
- Therefore calling setUserID will never work anymore and throws an error because start() doesn’t bring the SDK to a started state.

This PR solves these behaviors.