### PR TITLE
Upgrade Firebase libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext.versions = [
-        kotlin: '1.4.32',
+        kotlin: '1.6.0',
 
         androidPlugin: '3.0.0',
         androidTools: '27.0.2',

--- a/pushnotifications-integration-tests/build.gradle
+++ b/pushnotifications-integration-tests/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId "com.example.pushnotificationsintegrationtests"
         minSdkVersion 26
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 
@@ -35,14 +35,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     implementation 'com.squareup.retrofit2:converter-gson:2.3.0'
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     implementation project(':pushnotifications')
@@ -50,8 +50,8 @@ dependencies {
 
     androidTestImplementation 'org.nanohttpd:nanohttpd:2.2.0'
 
-    implementation "com.google.firebase:firebase-messaging:22.0.0"
-    implementation "com.google.firebase:firebase-iid:21.1.0"
+    implementation "com.google.firebase:firebase-messaging:23.4.0"
+    implementation "com.google.firebase:firebase-installations:17.2.0"
 
     androidTestImplementation 'org.awaitility:awaitility:3.1.5'
     androidTestImplementation 'org.awaitility:awaitility-kotlin:3.1.5'

--- a/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
+++ b/pushnotifications-integration-tests/src/androidTest/java/com/example/pushnotificationsintegrationtests/DeviceRegistrationTest.kt
@@ -2,7 +2,7 @@ package com.example.pushnotificationsintegrationtests
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.firebase.iid.FirebaseInstanceId
+import com.google.firebase.installations.FirebaseInstallations
 import com.pusher.pushnotifications.PushNotificationsInstance
 import com.pusher.pushnotifications.SubscriptionsChangedListener
 import com.pusher.pushnotifications.fcm.MessagingService
@@ -166,7 +166,7 @@ class DeviceRegistrationTest {
     val oldToken = errol.getInstanceStorage(instanceId).devices[storedDeviceId]?.token
     assertThat(oldToken, `is`(not(equalTo(""))))
 
-    FirebaseInstanceId.getInstance().deleteInstanceId()
+    FirebaseInstallations.getInstance().delete()
 
     await.atMost(DEVICE_REGISTRATION_WAIT_SECS, TimeUnit.SECONDS) until {
       // The server should have the new token now

--- a/pushnotifications-integration-tests/src/main/AndroidManifest.xml
+++ b/pushnotifications-integration-tests/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
             android:name="com.pusher.pushnotifications:override-host-url"
             android:value="http://localhost:8080" />
 
-        <activity android:name=".MainActivity">
+        <activity android:exported="true" android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/pushnotifications/build.gradle
+++ b/pushnotifications/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.9.2"
 
@@ -47,30 +47,30 @@ dependencies {
     implementation "dev.zacsweers.moshisealed:moshi-sealed-annotations:0.1.0"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.5.0"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.7.21"
 
-    compileOnly "com.google.firebase:firebase-messaging:22.0.0"
-    compileOnly "com.google.firebase:firebase-iid:21.1.0"
+    compileOnly "com.google.firebase:firebase-messaging:23.4.0"
+    compileOnly "com.google.firebase:firebase-installations:17.2.0"
 
     implementation("androidx.work:work-runtime-ktx:2.7.0")
     implementation 'androidx.concurrent:concurrent-futures:1.1.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4'
 
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'androidx.annotation:annotation:1.7.1'
 
     lintChecks project(':pushnotifications-lint')
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'androidx.test.ext:junit:1.1.3'
-    testImplementation 'androidx.test.ext:truth:1.4.0'
+    testImplementation 'androidx.test:core:1.5.0'
+    testImplementation 'androidx.test.ext:junit:1.1.5'
+    testImplementation 'androidx.test.ext:truth:1.5.0'
     testImplementation "org.mockito:mockito-core:2.13.0"
 
-    androidTestImplementation 'androidx.test:core:1.4.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test:core:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:3.12.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 
     testImplementation "net.bytebuddy:byte-buddy:1.8.22"
     testImplementation "net.bytebuddy:byte-buddy-agent:1.8.22"

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/PushNotificationsInstance.kt
@@ -3,7 +3,8 @@ package com.pusher.pushnotifications
 import java.util.regex.Pattern
 import android.content.Context
 import android.os.*
-import com.google.firebase.iid.FirebaseInstanceId
+import com.google.firebase.installations.FirebaseInstallations
+import com.google.firebase.messaging.FirebaseMessaging
 import com.pusher.pushnotifications.api.DeviceMetadata
 import com.pusher.pushnotifications.api.PushNotificationsAPI
 import com.pusher.pushnotifications.auth.TokenProvider
@@ -184,7 +185,7 @@ class PushNotificationsInstance @JvmOverloads constructor(
     }
 
     MessagingService.onRefreshToken = handleFcmToken
-    FirebaseInstanceId.getInstance().instanceId.addOnCompleteListener { task ->
+    FirebaseInstallations.getInstance().getToken(true).addOnCompleteListener { task ->
       if (!task.isSuccessful) {
         log.w("Failed to get the token from FCM", task.exception)
       } else {

--- a/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/MessagingService.kt
+++ b/pushnotifications/src/main/java/com/pusher/pushnotifications/fcm/MessagingService.kt
@@ -93,7 +93,7 @@ abstract class MessagingService: Service() {
           { token: String -> this.onNewToken(token) }
       )
 
-  override fun onBind(i: Intent?): IBinder = underlyingService.onBind(i!!)
+  override fun onBind(i: Intent?): IBinder? = underlyingService.onBind(i!!)
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
       underlyingService.onStartCommand(intent!!, flags, startId)


### PR DESCRIPTION
Actions taken:
* Upgraded firebase-messaging to the latest version to date (23.4.0). This is necessary due to Legacy FCM API deprecations
* Remove firebase-iid and started using Firebase Installations
* Updated some test libraries to newer versions

This breaking change needs to be released as a major version.

Fixes #117 and  #142